### PR TITLE
'protocol' and 'auth' options are ignored

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -13,13 +13,15 @@ module.exports = function Mongoosastic(schema, options){
     , _mapping = null
     , host = options && options.host ? options.host : 'localhost'
     , port = options && options.port ? options.port : 9200
-    , esClient  = new elasticsearch.Client({host: {host: host, port: port}})
+    , protocol = options && options.protocol ? options.protocol : 'http'
+    , auth = options && options.auth ? options.auth : null
+    , esClient  = new elasticsearch.Client({host: {host: host, port: port, protocol: protocol, auth: auth}})
     , bulk = options && options.bulk
     , bulkBuffer = []
     , bulkTimeout
 
   setUpMiddlewareHooks(schema)
-    
+
   /**
   * ElasticSearch Client
   */


### PR DESCRIPTION
This fixes an issue, where the 'protocol' and 'auth' options were ignored.
