### PR TITLE
get rid of "continue" when encounter objectid (issue #12)

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -52,9 +52,9 @@ function getMapping(cleanTree, prefix) {
     }
 
     // If it is a objectid make it a string.
-    if(value.type === 'objectid'){
+    if (value.type === 'objectid') {
       mapping[field].type = 'string';
-      continue;
+      // do not continue here so we can handle other es_ options
     }
 
     //If indexing a number, and no es_type specified, default to double


### PR DESCRIPTION
I have a `user` property in one of my schema, like

``` javascript
user: {
        type: Schema.Types.ObjectId,
        ref: 'User',
        es_indexed: true,
        es_index: 'not_analyzed'
    }
```

The original code will skip both `es_indexed` and `es_index` options, so I commented `continue` when encountered `objectid` so that we can simply take `objectid` as a simple string while mapping those `es_` options as well.
