### PR TITLE
Serialize on bulk calls. Serialize: this = full model.

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -67,10 +67,16 @@ module.exports = function Mongoosastic(schema, options){
       , type = options.type || typeName
 
     if(bulk) {
+      /**
+       * To serialize in bulk it needs the _id
+       */
+      var serialModel = serialize(this, mapping);
+      serialModel._id = this._id;
+
       bulkIndex({
         index: index,
         type: type,
-        model: this
+        model: serialModel
       })
       setImmediate(cb)
     } else {

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -3,7 +3,7 @@ module.exports = serialize;
 function _serializeObject(object, mapping) {
   var serialized = {};
   for (var field in mapping.properties) {
-    var val = serialize(object[field], mapping.properties[field]);
+    var val = serialize.call(object, object[field], mapping.properties[field]);
     if (val !== undefined) {
       serialized[field] = val;
     }
@@ -30,7 +30,7 @@ function serialize(model, mapping) {
   } else {
     if (mapping.cast && typeof(mapping.cast) !== 'function')
       throw new Error('es_cast must be a function');
-    model = mapping.cast ? mapping.cast(model) : model;
+    model = mapping.cast ? mapping.cast.call(this, model) : model;
     if (typeof model === 'object' && model !== null) {
       var name = model.constructor.name;
       if (name === 'ObjectID') {


### PR DESCRIPTION
- Serialize function now has the model as `this`.
- `cast` callback now has the entire model as `this`, so it can access another field:

```
...

es_cast: function() {
   return this.title;
}
...
```
- Bulk mode serializes too.

No new tests needed, this commit doesn't change functionality. All tests passed.
