### PR TITLE
In documentation files, rename "truncate" to "esTruncate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ mongodb. Use save for that.
 
 ### Truncating an index
 
-The static method truncate will deleted all documents from the associated index. This method combined with synchronise can be usefull in case of integration tests for example when each test case needs a cleaned up index in ElasticSearch.
+The static method `esTruncate` will delete all documents from the associated index. This method combined with synchronise can be usefull in case of integration tests for example when each test case needs a cleaned up index in ElasticSearch.
 
 ```javascript
-GarbageModel.truncate(function(err){...});
+GarbageModel.esTruncate(function(err){...});
 ```
 
 ## Mapping

--- a/test/truncate-test.js
+++ b/test/truncate-test.js
@@ -38,7 +38,7 @@ describe('Truncate', function() {
   after(function(done) {
     Dummy.remove(done);
   });
-  describe('truncate', function() {
+  describe('esTruncate', function() {
     it('should be able to truncate all documents', function(done) {
       Dummy.esTruncate(function(err) {
         Dummy.search({


### PR DESCRIPTION
I noticed that calling `GarbageModel.truncate()` does not do what I expect. It seems like this method was later renamed to `estruncate()`, but it wasn't updated in the documentation.
