### PR TITLE
Fix #64

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -128,6 +128,8 @@ module.exports = function Mongoosastic(schema, options) {
       options = {};
     }
 
+    setIndexNameIfUnset(this.modelName);
+
     var index = options.index || indexName,
       type = options.type || typeName;
 


### PR DESCRIPTION
This fix addresses cases where esTruncate was invoked without options and without calling a save or remove before it. This caused indexName to be missing when needed by esClient.deleteByQuery.