### PR TITLE
84 - improves synchronize high memory usage

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -172,13 +172,15 @@ module.exports = function Mongoosastic(schema, options) {
 
     setIndexNameIfUnset(this.modelName);
 
-    var stream = this.find(query).stream();
+    var stream = this.find(query).batchSize(50).stream();
 
     stream.on('data', function(doc) {
+      stream.pause();
       counter++;
       doc.save(function(err) {
         if (err) {
-          return em.emit('error', err);
+          em.emit('error', err);
+          stream.resume();
         }
 
         doc.on('es-indexed', function(err, doc) {
@@ -188,6 +190,7 @@ module.exports = function Mongoosastic(schema, options) {
           } else {
             em.emit('data', null, doc);
           }
+          stream.resume();
         });
       });
     });

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -180,7 +180,7 @@ module.exports = function Mongoosastic(schema, options) {
       doc.save(function(err) {
         if (err) {
           em.emit('error', err);
-          stream.resume();
+          return stream.resume();
         }
 
         doc.on('es-indexed', function(err, doc) {

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -163,6 +163,7 @@ module.exports = function Mongoosastic(schema, options) {
       };
 
     //Set indexing to be bulk when synchronizing to make synchronizing faster
+    //Set default values when not present
     bulk = bulk || {};
     bulk.delay = bulk.delay || 1000;
     bulk.size = bulk.size || 1000;

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -163,16 +163,16 @@ module.exports = function Mongoosastic(schema, options) {
       };
 
     //Set indexing to be bulk when synchronizing to make synchronizing faster
-    bulk = bulk || {
-      delay: 1000,
-      size: 1000
-    };
+    bulk = bulk || {};
+    bulk.delay = bulk.delay || 1000;
+    bulk.size = bulk.size || 1000;
+    bulk.batch = bulk.batch || 50;
 
     query = query || {};
 
     setIndexNameIfUnset(this.modelName);
 
-    var stream = this.find(query).batchSize(50).stream();
+    var stream = this.find(query).batchSize(bulk.batch).stream();
 
     stream.on('data', function(doc) {
       stream.pause();


### PR DESCRIPTION
Develop branch doesn't exist. So this is direct to master.

Added `stream.pause()` and `stream.resume()` to improve high memory usage.

Local tests

The app itself baseline ram usage is around ~80-100mb.
- Pre pull request = 2000 docs - ~360mb
- Post pull request = 2000 docs - ~140mb

There is still some data left in the ram but this solves a high percentage of it.

Also added a `batchSize` to mongo `stream` which saved ~10-20mb

Fix for #84 