### PR TITLE
index/unindex when findOneAndUpdate/findOneAndRemove

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -376,40 +376,48 @@ module.exports = function Mongoosastic(schema, options) {
     }
   }
 
+  function postRemove(doc) {
+    setIndexNameIfUnset(doc.constructor.modelName);
+
+    var options = {
+      index: indexName,
+      type: typeName,
+      tries: 3,
+      model: doc,
+      client: esClient
+    };
+
+    if (bulk) {
+      bulkDelete(options, nop);
+    } else {
+      deleteByMongoId(options, nop);
+    }
+  }
+
+  function postSave(doc) {
+    doc.index(function(err, res) {
+      if (!filter || !filter(doc)) {
+        doc.emit('es-indexed', err, res);
+      }
+    });
+  }
+
   /**
    * Use standard Mongoose Middleware hooks
    * to persist to Elasticsearch
    */
   function setUpMiddlewareHooks(schema) {
-    schema.post('remove', function(doc) {
-      setIndexNameIfUnset(doc.constructor.modelName);
-
-      var options = {
-        index: indexName,
-        type: typeName,
-        tries: 3,
-        model: doc,
-        client: esClient
-      };
-
-      if (bulk) {
-        bulkDelete(options, nop);
-      } else {
-        deleteByMongoId(options, nop);
-      }
-    });
+    /**
+     * Remove in elasticsearch on remove
+     */
+    schema.post('remove', postRemove);
+    schema.post('findOneAndRemove', postRemove);
 
     /**
      * Save in elasticsearch on save.
      */
-
-    schema.post('save', function(doc) {
-      doc.index(function(err, res) {
-        if (!filter || !filter(doc)) {
-          doc.emit('es-indexed', err, res);
-        }
-      });
-    });
+    schema.post('save', postSave);
+    schema.post('findOneAndUpdate', postSave);
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "lib/mongoosastic.js",
   "dependencies": {
-    "elasticsearch": "^5.0.0",
+    "elasticsearch": "^8.0.0",
     "mongoose": "^4.0.7",
     "nop": "^1.0.0"
   },


### PR DESCRIPTION
Mongoose support findOneAndUpdate/findOneAndRemove middlewares since version 4.0, 
so we can index/unindex documents with the help of the new middlewares now~~

Refers:
[Middleware](http://mongoosejs.com/docs/middleware.html#notes)
[pre, post middleware are not executed on findByIdAndUpdate](https://github.com/Automattic/mongoose/issues/964)