### PR TITLE
making docs more obvious in the case of 'es_' prefixed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,17 @@ var BookSchema = new Schema({
   , publicationDate: {type:Date, es_type:'date'} 
 }); 
 
+var BlogPost = mongoose.model('BlogPost', BlogPostSchema);
+
+BlogPost.createMapping(function(err, mapping) {
+  if (err) {
+    console.log('error creating mapping (you can safely ignore this)');
+    console.log(err);
+  } else {
+    console.log('mapping created!');
+    console.log(mapping);
+  }
+});
 ```
 This example uses a few other mapping fields... such as null_value and
 type (which overrides whatever value the schema type is, useful if you
@@ -482,6 +493,7 @@ Person.search({
 });
 
 ```
+
 See the Elasticsearch [Query DSL](http://www.elasticsearch.org/guide/reference/query-dsl/) docs for more information.
 
 You can also specify query options like [sorts](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-sort.html#search-request-sort)


### PR DESCRIPTION
I was having trouble with a schema that had es_prefixed fields:

```
var TagSchema = new Schema({
    name: {
        type: String,
        unique: true,
        required: true,
        // es_indexed: true,
        es_type: 'completion'
        // es_analyzer: 'autocomplete_analyzer'
    },
    userEditable: {
        type: Boolean
    },
    root: {
        type: Boolean
    },
    level: {
        type: Number
    },
    parent: {
        type: Schema.Types.ObjectId,
        ref: 'Tag'
    },
    child: [{
        type: Schema.Types.ObjectId,
        ref: 'Tag'
    }]
});
```

I was unable to figure out why the index was created in elastic search with the type 'string' when I was clearly providing es_type.  

I then realized what (I think) is the case, and that you need to create the mapping manually, otherwise the default index is created when the first document is indexed.  (e.g. type = 'string')

This is a fantastic library!  Some of the documentation and a couple more full examples would be helpful.  Let me know if you'd like me to help.