### PR TITLE
Feature/ all

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -45,20 +45,26 @@ function createEsClient(options) {
 }
 
 function createMappingIfNotPresent(options, cb) {
-  var settings = options.settings,
-    client = options.client,
+  var client = options.client,
     indexName = options.indexName,
     typeName = options.typeName,
-    schema = options.schema;
+    schema = options.schema,
+    settings = options.settings;
 
   generator.generateMapping(schema, function mapper(ignoredErr, mapping) {
-    var completeMapping = {};
+    var numberOfSettings,
+      completeMapping = {};
     completeMapping[typeName] = mapping;
 
-    if (options.settings) {
-      if ('_all' in options.settings) {
-        completeMapping[typeName]._all = options.settings._all;
-        delete settings._all;
+    if (settings) {
+      if ('_all' in settings) {
+        numberOfSettings = Object.keys(settings).length;
+        completeMapping[typeName]._all = settings._all;
+        if (numberOfSettings > 1) { /* checks if _all is the only key */
+          delete settings._all;
+        } else {
+          settings = undefined;
+        }
       }
     }
 

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -45,15 +45,36 @@ function createEsClient(options) {
 }
 
 function createMappingIfNotPresent(options, cb) {
-  var client = options.client,
+  var settings = {},
+    client = options.client,
     indexName = options.indexName,
     typeName = options.typeName,
-    schema = options.schema,
-    settings = options.settings;
+    schema = options.schema;
 
   generator.generateMapping(schema, function mapper(ignoredErr, mapping) {
-    var completeMapping = {};
+    var setting,
+      completeMapping = {};
     completeMapping[typeName] = mapping;
+
+    if (options.settings !== undefined) {
+      if ('_all' in options.settings) {
+        completeMapping[typeName]._all = options.settings._all;
+        if (Object.keys(options.settings).length > 1) {
+          for (setting in options.settings) {
+            if (setting !== '_all') {
+              settings[setting] = options.settings[setting];
+            }
+          }
+        } else {
+          settings = undefined;
+        }
+      } else {
+        settings = options.settings;
+      }
+    } else {
+      settings = options.settings;
+    }
+
     client.indices.exists({ index: indexName }, function existsCb(err, exists) {
       if (err) {
         return cb(err);

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -45,34 +45,21 @@ function createEsClient(options) {
 }
 
 function createMappingIfNotPresent(options, cb) {
-  var settings = {},
+  var settings = options.settings,
     client = options.client,
     indexName = options.indexName,
     typeName = options.typeName,
     schema = options.schema;
 
   generator.generateMapping(schema, function mapper(ignoredErr, mapping) {
-    var setting,
-      completeMapping = {};
+    var completeMapping = {};
     completeMapping[typeName] = mapping;
 
-    if (options.settings !== undefined) {
+    if (options.settings) {
       if ('_all' in options.settings) {
         completeMapping[typeName]._all = options.settings._all;
-        if (Object.keys(options.settings).length > 1) {
-          for (setting in options.settings) {
-            if (setting !== '_all') {
-              settings[setting] = options.settings[setting];
-            }
-          }
-        } else {
-          settings = undefined;
-        }
-      } else {
-        settings = options.settings;
+        delete settings._all;
       }
-    } else {
-      settings = options.settings;
     }
 
     client.indices.exists({ index: indexName }, function existsCb(err, exists) {

--- a/test/all-field-test.js
+++ b/test/all-field-test.js
@@ -68,22 +68,20 @@ describe('_all Field Option', function() {
     done();
   });
 
-  describe('Testing _all', function() {
-  	it('should map _all field', function(done) {
-      Song = mongoose.model('Song', SongSchema);
-      Song.createMapping(function(){
-        esClient.indices.getMapping({
-          index: 'songs',
-          type: 'song'
-        }, function(err, mapping){
-        	var field = mapping.song !== undefined ? /* elasticsearch 1.0 & 0.9 support */
-        	  mapping.song : /* ES 0.9.11 */
-        	  mapping.songs.mappings.song; /* ES 1.0.0 */
-        	field._all.enabled.should.eql(true);
-        	done();
-        });
+  it('should map _all field', function(done) {
+    Song.createMapping(function(){
+      esClient.indices.getMapping({
+        index: 'songs',
+        type: 'song'
+      }, function(err, mapping){
+      	var field = mapping.song !== undefined ? /* elasticsearch 1.0 & 0.9 support */
+      	  mapping.song : /* ES 0.9.11 */
+      	  mapping.songs.mappings.song; /* ES 1.0.0 */
+      	field._all.enabled.should.eql(true);
+      	done();
       });
-  	});
+    });
   });
+
 });
 

--- a/test/all-field-test.js
+++ b/test/all-field-test.js
@@ -1,0 +1,89 @@
+var mongoose = require('mongoose'),
+  elasticsearch = require('elasticsearch'),
+  esClient = new elasticsearch.Client({
+    deadTimeout: 0,
+    keepAlive: false
+  }),
+  async = require('async'),
+  config = require('./config'),
+  Schema = mongoose.Schema,
+  mongoosastic = require('../lib/mongoosastic');
+
+
+var SongSchema;
+var Song;
+
+describe('_all Field Option', function() {
+  before(function(done) {
+    mongoose.connect(config.mongoUrl, function() {
+      config.deleteIndexIfExists(['songs'], function() {
+        SongSchema = new Schema({
+          title: {type: String, es_index: 'not_analyzed'},
+          artist: {type: String, es_index: 'not_analyzed'},
+          genre: {type: String, es_index: 'not_analyzed', es_index: "no", es_include_in_all: false}
+        });
+        SongSchema.plugin(mongoosastic);
+        Song = mongoose.model('Song', SongSchema);
+        Song.createMapping({
+          "_all":{
+            "enabled": true
+          }
+        }, function() {
+          Song.remove(function() {
+            var songs = [
+              new Song({
+                title: 'Smells like Teen Spirit',
+                artist: 'Nirvana',
+                genre: 'Grunge'
+              }),
+              new Song({
+                title: 'Californication',
+                artist: 'Red Hot Chilli Peppers',
+                genre: 'Alternative Rock'
+              }),
+              new Song({
+                title: 'Dani California',
+                artist: 'Red Hot Chilli Peppers',
+                genre: 'Alternative Rock'
+              }),
+              new Song({
+                title: 'Hotel California',
+                artist: 'The Eagles',
+                genre: 'Rock'
+              })
+            ];
+            async.forEach(songs, config.saveAndWaitIndex, function() {
+              setTimeout(done, config.INDEXING_TIMEOUT);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  after(function(done) {
+    Song.esClient.close();
+    mongoose.disconnect();
+    esClient.close();
+    done();
+  });
+
+  describe('Testing _all', function() {
+  	it('should map _all field', function(done) {
+      Song = mongoose.model('Song', SongSchema);
+      Song.createMapping(function(){
+        esClient.indices.getMapping({
+          index: 'songs',
+          type: 'song'
+        }, function(err, mapping){
+        	var field = mapping.song !== undefined ? /* elasticsearch 1.0 & 0.9 support */
+        	  mapping.song : /* ES 0.9.11 */
+        	  mapping.songs.mappings.song; /* ES 1.0.0 */
+        	field._all.enabled.should.eql(true);
+        	done();
+        });
+      });
+  	});
+  });
+});
+


### PR DESCRIPTION
The [_all field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-all-field.html)  is useful if we want to search across multiple fields under certain circumstances. One of these circumstances is when we want to implement an autocomplete that searches across multiple fields using ngrams. 

[Here](https://qbox.io/blog/multi-field-partial-word-autocomplete-in-elasticsearch-using-ngrams) is a good article on how to do this with elasticsearch.

One issue I came across when trying to recreate this example using mongoosastic was that I could not find a way to add an "_all" field. This is because the createMapping method only supports settings, such as an analyzer.

Declaring an _all field in the createMapping method makes sense for me, that is why I modified the code to support **"_all"** that way.

Let me know if you have any comments.

  