### PR TITLE
Recognizes an es_type of nested with es_fields and maps it

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -58,10 +58,9 @@ function getMapping(cleanTree, inPrefix) {
     }
 
     // If there is no type, then it's an object with subfields.
-    if (!value.type) {
+    if (typeof value === 'object' && !value.type) {
       mapping[field].type = 'object';
       mapping[field].properties = getMapping(value, prefix + field);
-      continue;
     }
 
     // If it is a objectid make it a string.
@@ -82,6 +81,11 @@ function getMapping(cleanTree, inPrefix) {
       if (value.hasOwnProperty(prop) && prop.indexOf('es_') === 0 && prop !== 'es_indexed') {
         mapping[field][prop.replace(/^es_/, '')] = value[prop];
       }
+    }
+
+    // if type is never mapped, delete mapping
+    if (mapping[field].type === undefined) {
+      delete mapping[field];
     }
   }
 
@@ -111,6 +115,7 @@ function getCleanTree(tree, paths, inPrefix) {
     type = '',
     value = {},
     field,
+    prop,
     key,
     geoFound = false,
     prefix = inPrefix !== '' ? inPrefix + '.' : inPrefix;
@@ -132,25 +137,16 @@ function getCleanTree(tree, paths, inPrefix) {
       // If it is an nested schema
       if (value[0]) {
         // A nested array can contain complex objects
-        if (paths[field] && paths[field].schema && paths[field].schema.tree && paths[field].schema.paths) {
-          cleanTree[field] = getCleanTree(paths[field].schema.tree, paths[field].schema.paths, '');
-        } else if (paths[field] && paths[field].caster && paths[field].caster.instance) {
-          // Even for simple types the value can be an object if there is other attributes than type
-          if (typeof value[0] === 'object') {
-            cleanTree[field] = value[0];
-          } else {
-            cleanTree[field] = {};
+        nestedSchema(paths, field, cleanTree, value, prefix);
+      } else if (value.type && Array.isArray(value.type)) {
+        // An object with a nested array
+        nestedSchema(paths, field, cleanTree, value, prefix);
+        // Merge top level es settings
+        for (prop in value) {
+          // Map to field if it's an Elasticsearch option
+          if (value.hasOwnProperty(prop) && prop.indexOf('es_') === 0 && prop !== 'es_indexed') {
+            cleanTree[field][prop] = value[prop];
           }
-
-          cleanTree[field].type = paths[field].caster.instance.toLowerCase();
-        } else if (!paths[field] && prefix) {
-          if (paths[prefix + field] && paths[prefix + field].caster && paths[prefix + field].caster.instance) {
-            cleanTree[field] = {type: paths[prefix + field].caster.instance.toLowerCase()};
-          }
-        } else {
-          cleanTree[field] = {
-            type: 'object'
-          };
         }
       } else if (value === String || value === Object || value === Date || value === Number || value === Boolean || value === Array) {
         cleanTree[field] = {};
@@ -189,6 +185,30 @@ function getCleanTree(tree, paths, inPrefix) {
   }
 
   return cleanTree;
+}
+
+function nestedSchema(paths, field, cleanTree, value, prefix) {
+  // A nested array can contain complex objects
+  if (paths[field] && paths[field].schema && paths[field].schema.tree && paths[field].schema.paths) {
+    cleanTree[field] = getCleanTree(paths[field].schema.tree, paths[field].schema.paths, '');
+  } else if (paths[field] && paths[field].caster && paths[field].caster.instance) {
+    // Even for simple types the value can be an object if there is other attributes than type
+    if (typeof value[0] === 'object') {
+      cleanTree[field] = value[0];
+    } else {
+      cleanTree[field] = {};
+    }
+
+    cleanTree[field].type = paths[field].caster.instance.toLowerCase();
+  } else if (!paths[field] && prefix) {
+    if (paths[prefix + field] && paths[prefix + field].caster && paths[prefix + field].caster.instance) {
+      cleanTree[field] = {type: paths[prefix + field].caster.instance.toLowerCase()};
+    }
+  } else {
+    cleanTree[field] = {
+      type: 'object'
+    };
+  }
 }
 
 function Generator() {

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -163,6 +163,26 @@ describe('MappingGenerator', function() {
       });
     });
 
+    it('recognizes an es_type of nested with es_fields and maps it', function(done) {
+      var NameSchema = new Schema({
+        first_name: {type: String, es_index: 'not_analyzed'},
+        last_name: {type: String, es_index: 'not_analyzed'}
+      });
+      generator.generateMapping(new Schema({
+        name: {type: [NameSchema], es_indexed: true, es_type: 'nested', es_include_in_parent: true}
+      }), function(err, mapping) {
+        mapping.properties.name.type.should.eql('nested');
+        mapping.properties.name.include_in_parent.should.eql(true);
+        mapping.properties.name.properties.first_name.type.should.eql('string');
+        mapping.properties.name.properties.first_name.index.should.eql('not_analyzed');
+        mapping.properties.name.properties.last_name.type.should.eql('string');
+        mapping.properties.name.properties.last_name.index.should.eql('not_analyzed');
+        should.not.exist(mapping.properties.name.properties.es_include_in_parent);
+        should.not.exist(mapping.properties.name.properties.es_type);
+        done();
+      });
+    });
+
     it('recognizes a nested array with a simple type and maps it as a simple attribute', function(done) {
       generator.generateMapping(new Schema({
         contacts: [String]


### PR DESCRIPTION
I needed to create an index where a list of objects had a type ["nested"](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/mapping-nested-type.html) but mongoosastic didn't have a way to put specify es_ properties on parent properties of a nested schema, even though Elasticsearch proper does. This pull request allows those cases to be satisfied.

```
{
    "person" : {
        "properties" : {
            "name" : {
                "type" : "nested",
                "include_in_parent": true,
                "properties": {
                    "first_name" : {"type": "string", "index": "not_analyzed" },
                    "last_name"  : {"type": "string", "index": "not_analyzed" }
                }
            }
        }
    }
}
```

```
var NameSchema = new Schema({
  first_name: {type: String, es_index: 'not_analyzed'},
  last_name: {type: String, es_index: 'not_analyzed'}
});

var PersonSchema = new Schema({
  name: {type:[NameSchema], es_indexed:true, es_type:'nested', es_include_in_parent:true}
}
```
