### PR TITLE
Fix eslint warning & Update travis to use the latest services

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -137,10 +137,10 @@ function getCleanTree(tree, paths, inPrefix) {
       // If it is an nested schema
       if (value[0]) {
         // A nested array can contain complex objects
-        nestedSchema(paths, field, cleanTree, value, prefix);
+        nestedSchema(paths, field, cleanTree, value, prefix); // eslint-disable-line no-use-before-define
       } else if (value.type && Array.isArray(value.type)) {
         // An object with a nested array
-        nestedSchema(paths, field, cleanTree, value, prefix);
+        nestedSchema(paths, field, cleanTree, value, prefix); // eslint-disable-line no-use-before-define
         // Merge top level es settings
         for (prop in value) {
           // Map to field if it's an Elasticsearch option
@@ -187,6 +187,16 @@ function getCleanTree(tree, paths, inPrefix) {
   return cleanTree;
 }
 
+//
+// Define a nested schema
+//
+// @param paths
+// @param field
+// @param cleanTree
+// @param value
+// @param prefix
+// @return cleanTree modified
+//
 function nestedSchema(paths, field, cleanTree, value, prefix) {
   // A nested array can contain complex objects
   if (paths[field] && paths[field].schema && paths[field].schema.tree && paths[field].schema.paths) {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "babel-eslint": "^4.1.3",
     "coveralls": "^2.11.4",
     "eslint": "^1.5.1",
-    "eslint-config-airbnb": "0.0.9",
-    "istanbul": "^0.3.21",
+    "eslint-config-airbnb": "1.0.0",
+    "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
     "should": "^7.1.0"
   },


### PR DESCRIPTION
* Fix eslint warning:
```
  140:9  warning  "nestedSchema" was used before it was defined  no-use-before-define
  143:9  warning  "nestedSchema" was used before it was defined  no-use-before-define
```
* Bump eslint-config-airbnb & istanbul
* Install the latest version of MongoDB & Elasticsearch for Travis tests