### PR TITLE
Fix #91: add option "transform" to transform serialized model before indexation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options are:
 * `hydrateOptions` - options to pass into hydrate function
 * `bulk` - size and delay options for bulk indexing
 * `filter` - the function used for filtered indexing
+* `transform` - the function used to transform serialized document before indexing
 
 
 To have a model indexed into Elasticsearch simply add the plugin.

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -157,7 +157,8 @@ function Mongoosastic(schema, pluginOpts) {
     alwaysHydrate = options && options.hydrate,
     defaultHydrateOptions = options && options.hydrateOptions,
     bulk = options && options.bulk,
-    filter = options && options.filter;
+    filter = options && options.filter,
+    transform = options && options.transform;
 
   if (options.esClient) {
     esClient = options.esClient;
@@ -276,11 +277,17 @@ function Mongoosastic(schema, pluginOpts) {
     index = opts.index || indexName;
     type = opts.type || typeName;
 
+    /**
+     * Serialize the model, and apply transformation
+     */
+    serialModel = serialize(this, mapping);
+    if (transform) serialModel = transform(serialModel, this);
+
     if (bulk) {
       /**
        * To serialize in bulk it needs the _id
        */
-      serialModel = serialize(this, mapping);
+
       serialModel._id = this._id;
 
       bulkIndex({
@@ -294,7 +301,7 @@ function Mongoosastic(schema, pluginOpts) {
         index: index,
         type: type,
         id: this._id.toString(),
-        body: serialize(this, mapping)
+        body: serialModel
       }, cb);
     }
   };

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -1,0 +1,59 @@
+var mongoose = require('mongoose'),
+  config = require('./config'),
+  Schema = mongoose.Schema,
+  Repo,
+  mongoosastic = require('../lib/mongoosastic');
+
+// -- Only index specific field
+var RepoSchema = new Schema({
+  name: {
+    type:String,
+    es_indexed:true
+  },
+  settingLicense: {
+    type: String
+  },
+  detectedLicense: {
+    type: String
+  }
+});
+
+
+RepoSchema.plugin(mongoosastic, {
+  transform: function(data, repo) {
+    data.license = repo.settingLicense || repo.detectedLicense;
+    return data;
+  }
+});
+
+Repo = mongoose.model('Repo', RepoSchema);
+
+describe('Transform mode', function() {
+  this.timeout(5000);
+
+  before(function(done) {
+    config.deleteIndexIfExists(['repos'], function() {
+      mongoose.connect(config.mongoUrl, function() {
+        var client = mongoose.connections[0].db;
+        client.collection('repos', function() {
+          Repo.remove(done);
+        });
+      });
+    });
+  });
+
+  after(function(done) {
+    mongoose.disconnect();
+    Repo.esClient.close();
+    done();
+  });
+
+  it('should index with field "fullTitle"', function(done) {
+    config.createModelAndEnsureIndex(Repo, {name: 'LOTR', settingLicense: '', detectedLicense: 'Apache'}, function() {
+      Repo.search({query_string: {query: 'Apache'}}, function(err, results) {
+        results.hits.total.should.eql(1);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes #91, by adding an optional `transform` method:

Here is an example, inspired by my use-case:

```js
var Repo = new Schema({
    name: {
        type:String,
        es_indexed:true
    },
    settingLicense: {
        type: String
    },
    detectedLicense: {
        type: String
    }
})

Repo.plugin(mongoosastic, {
    transform: function(data, repo) {
        data.license = repo.settingLicense || repo.detectedLicense;
        return data;
    }
});
```