### PR TITLE
Add option "customProperties" to extend mapping 

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -49,11 +49,19 @@ function createMappingIfNotPresent(options, cb) {
     indexName = options.indexName,
     typeName = options.typeName,
     schema = options.schema,
-    settings = options.settings;
+    settings = options.settings,
+    properties = options.properties;
 
   generator.generateMapping(schema, function mapper(ignoredErr, mapping) {
     var completeMapping = {};
     completeMapping[typeName] = mapping;
+
+    if (properties) {
+      Object.keys(properties).map(function mapCustomProperty(key) {
+        completeMapping[typeName].properties[key] = properties[key];
+      });
+    }
+
     client.indices.exists({ index: indexName }, function existsCb(err, exists) {
       if (err) {
         return cb(err);
@@ -158,7 +166,8 @@ function Mongoosastic(schema, pluginOpts) {
     defaultHydrateOptions = options && options.hydrateOptions,
     bulk = options && options.bulk,
     filter = options && options.filter,
-    transform = options && options.transform;
+    transform = options && options.transform,
+    customProperties = options && options.customProperties;
 
   if (options.esClient) {
     esClient = options.esClient;
@@ -251,7 +260,8 @@ function Mongoosastic(schema, pluginOpts) {
       indexName: indexName,
       typeName: typeName,
       schema: schema,
-      settings: settings
+      settings: settings,
+      properties: customProperties
     }, cb);
   };
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "main": "lib/mongoosastic.js",
   "dependencies": {
-    "elasticsearch": "^8.2.0",
-    "mongoose": "^4.1.8"
+    "elasticsearch": "^8.2.0"
   },
   "devDependencies": {
     "async": "^1.4.2",
@@ -27,7 +26,8 @@
     "eslint-config-airbnb": "0.0.9",
     "istanbul": "^0.3.21",
     "mocha": "^2.3.3",
-    "should": "^7.1.0"
+    "should": "^7.1.0",
+    "mongoose": "^4.1.8"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/test/custom-mapping-test.js
+++ b/test/custom-mapping-test.js
@@ -1,0 +1,58 @@
+var mongoose = require('mongoose'),
+  config = require('./config'),
+  Schema = mongoose.Schema,
+  Phone,
+  mongoosastic = require('../lib/mongoosastic');
+
+// -- Only index specific field
+var PhoneSchema = new Schema({
+  name: {
+    type: String,
+    es_indexed: true
+  }
+});
+
+
+PhoneSchema.plugin(mongoosastic, {
+  transform: function(data, phone) {
+    data.created = new Date(phone._id.generationTime * 1000);
+    return data;
+  },
+  customProperties: {
+    created: {
+      type: 'date'
+    }
+  }
+});
+
+Phone = mongoose.model('Phone', PhoneSchema);
+
+describe('Custom Properties for Mapping', function() {
+  this.timeout(5000);
+
+  before(function(done) {
+    config.deleteIndexIfExists(['phones'], function() {
+      mongoose.connect(config.mongoUrl, function() {
+        var client = mongoose.connections[0].db;
+        client.collection('phones', function() {
+          Phone.remove(done);
+        });
+      });
+    });
+  });
+
+  after(function(done) {
+    mongoose.disconnect();
+    Phone.esClient.close();
+    done();
+  });
+
+  it('should index with field "fullTitle"', function(done) {
+    config.createModelAndEnsureIndex(Phone, {name: 'iPhone'}, function() {
+      Phone.search({query_string: {query: 'iPhone'}}, {sort: 'created:asc'}, function(err, results) {
+        results.hits.total.should.eql(1);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR is related to #127 and #91. It allow an option `customProperties` that extend the mapping generated by mongoosastic.

:warning: This PR also moves `mongoose` to `devDependencies`, I don;t see any reason why it should be in `dependencies`, but let me know if I'm wrong.

Example:

```js
var Repo = new Schema({
    name: {
        type:String,
        es_indexed:true
    },
    settingLicense: {
        type: String
    },
    detectedLicense: {
        type: String
    }
})

Repo.plugin(mongoosastic, {
    transform: function(data, repo) {
        data.license = repo.settingLicense || repo.detectedLicense;
        return data;
    },
    customProperties: {
        license: {
             type: 'string',
             boost: 2.0
        }
    }
});
```
