### PR TITLE
Unindex when filtered

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -269,7 +269,12 @@ function Mongoosastic(schema, pluginOpts) {
     }
 
     if (filter && filter(this)) {
-      return cb();
+      return this.unIndex(function() {
+      /**
+       * Ignore error since the model has probably never been indexed
+       */
+        cb();
+      });
     }
 
     setIndexNameIfUnset(this.constructor.modelName);
@@ -399,7 +404,7 @@ function Mongoosastic(schema, pluginOpts) {
           return stream.resume();
         }
 
-        doc.on('es-indexed', function onIndex(indexErr, inDoc) {
+        function onIndex(indexErr, inDoc) {
           counter--;
           if (indexErr) {
             em.emit('error', indexErr);
@@ -407,7 +412,10 @@ function Mongoosastic(schema, pluginOpts) {
             em.emit('data', null, inDoc);
           }
           stream.resume();
-        });
+        }
+
+        doc.on('es-indexed', onIndex);
+        doc.on('es-filtered', onIndex);
       });
     });
 
@@ -567,6 +575,8 @@ function Mongoosastic(schema, pluginOpts) {
       doc.index(function onIndex(err, res) {
         if (!filter || !filter(doc)) {
           doc.emit('es-indexed', err, res);
+        } else {
+          doc.emit('es-filtered', err, res);
         }
       });
     }

--- a/test/config.js
+++ b/test/config.js
@@ -28,9 +28,13 @@ function deleteIndexIfExists(indexes, done) {
 
 function createModelAndEnsureIndex(Model, obj, cb) {
   var dude = new Model(obj);
-  dude.save(function() {
+  dude.save(function(err) {
+    if (err) return dude(err);
+
     dude.on('es-indexed', function() {
-      setTimeout(cb, INDEXING_TIMEOUT);
+      setTimeout(function() {
+        cb(null, dude);
+      }, INDEXING_TIMEOUT);
     });
   });
 }
@@ -43,7 +47,10 @@ function createModelAndSave(Model, obj, cb) {
 function saveAndWaitIndex(model, cb) {
   model.save(function(err) {
     if (err) cb(err);
-    else model.on('es-indexed', cb);
+    else {
+      model.once('es-indexed', cb);
+      model.once('es-filtered', cb);
+    }
   });
 }
 


### PR DESCRIPTION
Currently, if we saved a model that is not filtered, it'll be indexed; but if we changed its property that caused it to be filtered, it'll stay in the index.

This PR simply unIndex the document if we try to index a document that is filtered. It adds an event `es-filtered` (used to fix #126), triggered when the model is not indexed but filtered (after ensuring that it's unindexed).
