### PR TITLE
Add support for ElasticSearch 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: node_js
 node_js:
   - 4
   - stable
+  - 0.12
+  - 0.10
 
 services:
   - mongodb

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Mongoosastic is a [mongoose](http://mongoosejs.com/) plugin that can automatical
 - [Queries](#queries)
   - [Hydration](#hydration)
 
+## Elasticsearch 2.x plugin requirement
+
+```bash
+./bin/plugin install mapper-size
+```
+
+
 ## Installation
 
 The latest version of this package will be as close as possible to the latest `elasticsearch` and `mongoose` packages. If you are working with latest mongoose package, install normally: 

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -1,4 +1,3 @@
-
 //
 // Get type from the mongoose schema
 //
@@ -212,7 +211,9 @@ function nestedSchema(paths, field, cleanTree, value, prefix) {
     cleanTree[field].type = paths[field].caster.instance.toLowerCase();
   } else if (!paths[field] && prefix) {
     if (paths[prefix + field] && paths[prefix + field].caster && paths[prefix + field].caster.instance) {
-      cleanTree[field] = {type: paths[prefix + field].caster.instance.toLowerCase()};
+      cleanTree[field] = {
+        type: paths[prefix + field].caster.instance.toLowerCase()
+      };
     }
   } else {
     cleanTree[field] = {
@@ -221,15 +222,16 @@ function nestedSchema(paths, field, cleanTree, value, prefix) {
   }
 }
 
-function Generator() {
-}
+function Generator() {}
 
 Generator.prototype.generateMapping = function generateMapping(schema, cb) {
-  var cleanTree = getCleanTree(schema.tree, schema.paths, ''), mapping;
+  var cleanTree = getCleanTree(schema.tree, schema.paths, ''),
+    mapping;
   delete cleanTree[schema.get('versionKey')];
   mapping = getMapping(cleanTree, '');
-  cb(null, {properties: mapping});
+  cb(null, {
+    properties: mapping
+  });
 };
 
 module.exports = Generator;
-

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -1,3 +1,5 @@
+/* eslint object-shorthand: 0 */
+
 var elasticsearch = require('elasticsearch'),
   Generator = require('./mapping-generator'),
   generator = new Generator(),
@@ -11,7 +13,9 @@ function isString(subject) {
 }
 
 function isStringArray(arr) {
-  return arr.filter && arr.length === (arr.filter(function check(item) { return (typeof item === 'string'); })).length;
+  return arr.filter && arr.length === (arr.filter(function check(item) {
+    return (typeof item === 'string');
+  })).length;
 }
 
 function getMapping(schema) {
@@ -62,7 +66,9 @@ function createMappingIfNotPresent(options, cb) {
       });
     }
 
-    client.indices.exists({ index: indexName }, function existsCb(err, exists) {
+    client.indices.exists({
+      index: indexName
+    }, function existsCb(err, exists) {
       if (err) {
         return cb(err);
       }
@@ -75,7 +81,10 @@ function createMappingIfNotPresent(options, cb) {
         }, cb);
 
       }
-      return client.indices.create({ index: indexName, body: settings }, function indexCb(indexErr) {
+      return client.indices.create({
+        index: indexName,
+        body: settings
+      }, function indexCb(indexErr) {
         if (indexErr) {
           return cb(indexErr);
         }
@@ -98,7 +107,11 @@ function hydrate(res, model, options, cb) {
       return result._id;
     }),
 
-    query = model.find({_id: {$in: ids}}),
+    query = model.find({
+      _id: {
+        $in: ids
+      }
+    }),
     hydrateOptions = options.hydrateOptions;
 
   // Build Mongoose query based on hydrate options
@@ -158,7 +171,8 @@ function deleteByMongoId(options, cb) {
 function Mongoosastic(schema, pluginOpts) {
   var options = pluginOpts || {};
 
-  var bulkTimeout, bulkBuffer = [], esClient,
+  var bulkTimeout, bulkBuffer = [],
+    esClient,
     mapping = getMapping(schema),
     indexName = options && options.index,
     typeName = options && options.type,
@@ -200,14 +214,14 @@ function Mongoosastic(schema, pluginOpts) {
       return;
     }
 
-    if (bulkBuffer.length >= (bulk.size || 1000)) {
+    if (bulkBuffer.length >= ((bulk && bulk.size) || 1000)) {
       schema.statics.flush();
       clearBulkTimeout();
     } else if (bulkTimeout === undefined) {
       bulkTimeout = setTimeout(function delayedBulkAdd() {
         schema.statics.flush();
         clearBulkTimeout();
-      }, bulk.delay || 1000);
+      }, (bulk && bulk.delay) || 1000);
     }
   }
 
@@ -227,7 +241,7 @@ function Mongoosastic(schema, pluginOpts) {
       index: {
         _index: opts.index || indexName,
         _type: opts.type || typeName,
-        _id: opts.model._id.toString()
+        _id: opts._id.toString()
       }
     });
     bulkAdd(opts.model);
@@ -247,7 +261,8 @@ function Mongoosastic(schema, pluginOpts) {
    * @param cb Function
    */
   schema.statics.createMapping = function createMapping(inSettings, inCb) {
-    var cb = inCb, settings = inSettings;
+    var cb = inCb,
+      settings = inSettings;
     if (arguments.length < 2) {
       cb = inSettings || nop;
       settings = undefined;
@@ -271,7 +286,8 @@ function Mongoosastic(schema, pluginOpts) {
    */
   schema.methods.index = function schemaIndex(inOpts, inCb) {
     var index, type, serialModel,
-      cb = inCb, opts = inOpts;
+      cb = inCb,
+      opts = inOpts;
 
     if (arguments.length < 2) {
       cb = inOpts || nop;
@@ -279,10 +295,10 @@ function Mongoosastic(schema, pluginOpts) {
     }
 
     if (filter && filter(this)) {
-      return this.unIndex(function() {
-      /**
-       * Ignore error since the model has probably never been indexed
-       */
+      return this.unIndex(function unIndexCb() {
+        /**
+         * Ignore error since the model has probably never been indexed
+         */
         cb();
       });
     }
@@ -299,16 +315,11 @@ function Mongoosastic(schema, pluginOpts) {
     if (transform) serialModel = transform(serialModel, this);
 
     if (bulk) {
-      /**
-       * To serialize in bulk it needs the _id
-       */
-
-      serialModel._id = this._id;
-
       bulkIndex({
         index: index,
         type: type,
-        model: serialModel
+        model: serialModel,
+        _id: this._id
       });
       setImmediate(cb);
     } else {
@@ -327,7 +338,8 @@ function Mongoosastic(schema, pluginOpts) {
    * @param cb - callback when unIndex is complete
    */
   schema.methods.unIndex = function unIndex(inOpts, inCb) {
-    var opts = inOpts, cb = inCb;
+    var opts = inOpts,
+      cb = inCb;
 
     if (arguments.length < 2) {
       cb = inOpts || nop;
@@ -355,8 +367,9 @@ function Mongoosastic(schema, pluginOpts) {
    * @param cb - callback when truncation is complete
    */
   schema.statics.esTruncate = function esTruncate(inOpts, inCb) {
-    var index, type,
-      opts = inOpts, cb = inCb;
+    var opts = inOpts,
+      cb = inCb,
+      esQuery;
 
     if (arguments.length < 2) {
       cb = inOpts || nop;
@@ -365,18 +378,31 @@ function Mongoosastic(schema, pluginOpts) {
 
     setIndexNameIfUnset(this.modelName);
 
-    index = opts.index || indexName;
-    type = opts.type || typeName;
+    opts.index = opts.index || indexName;
+    opts.type = opts.type || typeName;
 
-    esClient.deleteByQuery({
-      index: index,
-      type: type,
+    esQuery = {
       body: {
         query: {
           match_all: {}
         }
+      },
+      index: opts.index,
+      type: opts.type
+    };
+
+    esClient.search(esQuery, function searchCb(err, res) {
+      if (err) {
+        return cb(err);
       }
-    }, cb);
+      if (res.hits.total) {
+        res.hits.hits.forEach(function truncateEach(doc) {
+          opts.model = doc;
+          bulkDelete(opts, nop);
+        });
+        cb();
+      }
+    });
   };
 
   /**
@@ -520,7 +546,9 @@ function Mongoosastic(schema, pluginOpts) {
   };
 
   schema.statics.esCount = function esCount(inQuery, inCb) {
-    var cb = inCb, query = inQuery, esQuery;
+    var cb = inCb,
+      query = inQuery,
+      esQuery;
 
     setIndexNameIfUnset(this.modelName);
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -2,7 +2,8 @@ module.exports = function serialize(model, mapping) {
   var name, outModel;
 
   function _serializeObject(object, mappingData) {
-    var serialized = {}, field, val;
+    var serialized = {},
+      field, val;
     for (field in mappingData.properties) {
       if (mappingData.properties.hasOwnProperty(field)) {
         val = serialize.call(object, object[field], mappingData.properties[field]);
@@ -46,4 +47,3 @@ module.exports = function serialize(model, mapping) {
   return outModel;
 
 };
-

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
   },
   "main": "lib/mongoosastic.js",
   "dependencies": {
-    "elasticsearch": "^8.2.0"
+    "elasticsearch": "^10.0.1"
   },
   "devDependencies": {
-    "async": "^1.4.2",
-    "babel-eslint": "^4.1.3",
+    "async": "^1.5.0",
+    "babel-eslint": "^4.1.6",
     "coveralls": "^2.11.4",
-    "eslint": "^1.5.1",
-    "eslint-config-airbnb": "1.0.0",
-    "istanbul": "^0.4.0",
-    "mocha": "^2.3.3",
-    "should": "^7.1.0",
-    "mongoose": "^4.1.8"
+    "eslint": "^1.10.3",
+    "eslint-config-airbnb": "^2.0.0",
+    "istanbul": "^0.4.1",
+    "mocha": "^2.3.4",
+    "should": "^8.0.0",
+    "mongoose": "^4.3.0"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/test/alternative-index-method-test.js
+++ b/test/alternative-index-method-test.js
@@ -25,11 +25,17 @@ describe('Index Method', function() {
   });
 
   it('should be able to index it directly without saving', function(done) {
-    Tweet.findOne({message: 'I know kung-fu!'}, function(err, doc) {
+    Tweet.findOne({
+      message: 'I know kung-fu!'
+    }, function(err, doc) {
       doc.message = 'I know nodejitsu!';
       doc.index(function() {
         setTimeout(function() {
-          Tweet.search({query_string: {query: 'know'}}, function(err1, res) {
+          Tweet.search({
+            query_string: {
+              query: 'know'
+            }
+          }, function(err1, res) {
             res.hits.hits[0]._source.message.should.eql('I know nodejitsu!');
             done();
           });
@@ -39,11 +45,21 @@ describe('Index Method', function() {
   });
 
   it('should be able to index to alternative index', function(done) {
-    Tweet.findOne({message: 'I know kung-fu!'}, function(err, doc) {
+    Tweet.findOne({
+      message: 'I know kung-fu!'
+    }, function(err, doc) {
       doc.message = 'I know taebo!';
-      doc.index({index: 'public_tweets'}, function() {
+      doc.index({
+        index: 'public_tweets'
+      }, function() {
         setTimeout(function() {
-          Tweet.search({query_string: {query: 'know'}}, {index: 'public_tweets'}, function(err1, res) {
+          Tweet.search({
+            query_string: {
+              query: 'know'
+            }
+          }, {
+            index: 'public_tweets'
+          }, function(err1, res) {
             res.hits.hits[0]._source.message.should.eql('I know taebo!');
             done();
           });
@@ -53,11 +69,20 @@ describe('Index Method', function() {
   });
 
   it('should be able to index to alternative index and type', function(done) {
-    Tweet.findOne({message: 'I know kung-fu!'}, function(err, doc) {
+    Tweet.findOne({
+      message: 'I know kung-fu!'
+    }, function(err, doc) {
       doc.message = 'I know taebo!';
-      doc.index({index: 'public_tweets', type: 'utterings'}, function() {
+      doc.index({
+        index: 'public_tweets',
+        type: 'utterings'
+      }, function() {
         setTimeout(function() {
-          Tweet.search({query_string: {query: 'know'}}, {
+          Tweet.search({
+            query_string: {
+              query: 'know'
+            }
+          }, {
             index: 'public_tweets',
             type: 'utterings'
           }, function(err1, res) {

--- a/test/boost-field-test.js
+++ b/test/boost-field-test.js
@@ -11,9 +11,17 @@ var mongoose = require('mongoose'),
 
 var TweetSchema = new Schema({
   user: String,
-  post_date: {type: Date, es_type: 'date'},
-  message: {type: String},
-  title: {type: String, es_boost: 2.0}
+  post_date: {
+    type: Date,
+    es_type: 'date'
+  },
+  message: {
+    type: String
+  },
+  title: {
+    type: String,
+    es_boost: 2.0
+  }
 });
 
 

--- a/test/bulk-test.js
+++ b/test/bulk-test.js
@@ -60,7 +60,9 @@ describe('Bulk mode', function() {
     // This timeout is important, as Elasticsearch is "near-realtime" and the index/deletion takes time that
     // needs to be taken into account in these tests
     setTimeout(function() {
-      Book.search({match_all: {}}, function(err, results) {
+      Book.search({
+        match_all: {}
+      }, function(err, results) {
         results.should.have.property('hits').with.property('total', 52);
         done();
       });

--- a/test/config.js
+++ b/test/config.js
@@ -59,7 +59,8 @@ function bookTitlesArray() {
       'American Gods',
       'Gods of the Old World',
       'American Gothic'
-    ], idx;
+    ],
+    idx;
   for (idx = 0; idx < 50; idx++) {
     books.push('ABABABA' + idx);
   }
@@ -82,4 +83,3 @@ module.exports = {
     esClient.close();
   }
 };
-

--- a/test/connection-test.js
+++ b/test/connection-test.js
@@ -67,7 +67,7 @@ describe('Elasticsearch Connection', function() {
     var Dummy2;
 
     DummySchema.plugin(mongoosastic);
-    Dummy2= mongoose.model('Dummy2', DummySchema, 'dummys');
+    Dummy2 = mongoose.model('Dummy2', DummySchema, 'dummys');
 
     tryDummySearch(Dummy2, done);
 
@@ -105,7 +105,9 @@ describe('Elasticsearch Connection', function() {
 
   it('should be able to connect with an existing elasticsearch client', function(done) {
 
-    var esClient = new elasticsearch.Client({host: 'localhost:9200'});
+    var esClient = new elasticsearch.Client({
+      host: 'localhost:9200'
+    });
 
     esClient.ping({
       requestTimeout: 1000
@@ -128,4 +130,3 @@ describe('Elasticsearch Connection', function() {
   });
 
 });
-

--- a/test/count-test.js
+++ b/test/count-test.js
@@ -7,9 +7,17 @@ var mongoose = require('mongoose'),
 
 var CommentSchema = new Schema({
   user: String,
-  post_date: {type: Date, es_type: 'date'},
-  message: {type: String},
-  title: {type: String, es_boost: 2.0}
+  post_date: {
+    type: Date,
+    es_type: 'date'
+  },
+  message: {
+    type: String
+  },
+  title: {
+    type: String,
+    es_boost: 2.0
+  }
 });
 
 

--- a/test/custom-mapping-test.js
+++ b/test/custom-mapping-test.js
@@ -48,8 +48,16 @@ describe('Custom Properties for Mapping', function() {
   });
 
   it('should index with field "fullTitle"', function(done) {
-    config.createModelAndEnsureIndex(Phone, {name: 'iPhone'}, function() {
-      Phone.search({query_string: {query: 'iPhone'}}, {sort: 'created:asc'}, function(err, results) {
+    config.createModelAndEnsureIndex(Phone, {
+      name: 'iPhone'
+    }, function() {
+      Phone.search({
+        query_string: {
+          query: 'iPhone'
+        }
+      }, {
+        sort: 'created:asc'
+      }, function(err, results) {
         results.hits.total.should.eql(1);
         done();
       });

--- a/test/filtering-test.js
+++ b/test/filtering-test.js
@@ -6,8 +6,19 @@ var mongoose = require('mongoose'),
 
 // -- Only index specific field
 var MovieSchema = new Schema({
-  title: {type: String, required: true, default: '', es_indexed: true},
-  genre: {type: String, required: true, default: '', enum: ['horror', 'action', 'adventure', 'other'], es_indexed: true}
+  title: {
+    type: String,
+    required: true,
+    default: '',
+    es_indexed: true
+  },
+  genre: {
+    type: String,
+    required: true,
+    default: '',
+    enum: ['horror', 'action', 'adventure', 'other'],
+    es_indexed: true
+  }
 });
 
 
@@ -40,8 +51,15 @@ describe('Filter mode', function() {
   });
 
   it('should index horror genre', function(done) {
-    config.createModelAndEnsureIndex(Movie, {title: 'LOTR', genre: 'horror'}, function() {
-      Movie.search({term: {genre: 'horror'}}, function(err, results) {
+    config.createModelAndEnsureIndex(Movie, {
+      title: 'LOTR',
+      genre: 'horror'
+    }, function() {
+      Movie.search({
+        term: {
+          genre: 'horror'
+        }
+      }, function(err, results) {
         results.hits.total.should.eql(1);
         done();
       });
@@ -49,8 +67,15 @@ describe('Filter mode', function() {
   });
 
   it('should not index action genre', function(done) {
-    config.createModelAndSave(Movie, {title: 'Man in Black', genre: 'action'}, function() {
-      Movie.search({term: {genre: 'action'}}, function(err, results) {
+    config.createModelAndSave(Movie, {
+      title: 'Man in Black',
+      genre: 'action'
+    }, function() {
+      Movie.search({
+        term: {
+          genre: 'action'
+        }
+      }, function(err, results) {
         results.hits.total.should.eql(0);
         done();
       });
@@ -58,14 +83,25 @@ describe('Filter mode', function() {
   });
 
   it('should unindex filtered models', function(done) {
-    config.createModelAndEnsureIndex(Movie, {title: 'REC', genre: 'horror'}, function(errSave, movie) {
-      Movie.search({term: {title: 'rec'}}, function(err, results) {
+    config.createModelAndEnsureIndex(Movie, {
+      title: 'REC',
+      genre: 'horror'
+    }, function(errSave, movie) {
+      Movie.search({
+        term: {
+          title: 'rec'
+        }
+      }, function(err, results) {
         results.hits.total.should.eql(1);
 
         movie.genre = 'action';
         config.saveAndWaitIndex(movie, function() {
           setTimeout(function() {
-            Movie.search({term: {title: 'rec'}}, function(errSearch2, results2) {
+            Movie.search({
+              term: {
+                title: 'rec'
+              }
+            }, function(errSearch2, results2) {
               results2.hits.total.should.eql(0);
               done();
             });

--- a/test/geo-test.js
+++ b/test/geo-test.js
@@ -17,7 +17,9 @@ describe('GeoTest', function() {
           myId: Number,
           frame: {
             coordinates: [],
-            type: {type: String},
+            type: {
+              type: String
+            },
             geo_shape: {
               type: String,
               es_type: 'geo_shape',
@@ -104,7 +106,9 @@ describe('GeoTest', function() {
       // ES request
       GeoModel.search({
         match_all: {}
-      }, {sort: 'myId:asc'}, function(err, res) {
+      }, {
+        sort: 'myId:asc'
+      }, function(err, res) {
         if (err) throw err;
         res.hits.total.should.eql(2);
         res.hits.hits[0]._source.frame.type.should.eql('envelope');
@@ -130,7 +134,9 @@ describe('GeoTest', function() {
           setTimeout(function() {
             GeoModel.search({
               match_all: {}
-            }, {sort: 'myId:asc'}, function(err, res) {
+            }, {
+              sort: 'myId:asc'
+            }, function(err, res) {
               if (err) throw err;
               res.hits.total.should.eql(2);
               res.hits.hits[0]._source.frame.type.should.eql('envelope');

--- a/test/highlight-features-test.js
+++ b/test/highlight-features-test.js
@@ -36,7 +36,7 @@ describe('Highlight search', function() {
             new Text({
               title: 'The Light Fantastic',
               quote: 'The death of the warrior or the old man or the little child, this I understand, and I take ' +
-              'away the pain and end the suffering. I do not understand this death-of-the-mind'
+                'away the pain and end the suffering. I do not understand this death-of-the-mind'
             }),
             new Text({
               title: 'Equal Rites',

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,9 +11,18 @@ var mongoose = require('mongoose'),
 // -- Only index specific field
 var TalkSchema = new Schema({
   speaker: String,
-  year: {type: Number, es_indexed: true},
-  title: {type: String, es_indexed: true},
-  abstract: {type: String, es_indexed: true},
+  year: {
+    type: Number,
+    es_indexed: true
+  },
+  title: {
+    type: String,
+    es_indexed: true
+  },
+  abstract: {
+    type: String,
+    es_indexed: true
+  },
   bio: String
 });
 
@@ -22,12 +31,24 @@ var BumSchema = new Schema({
 });
 
 var PersonSchema = new Schema({
-  name: {type: String, es_indexed: true},
-  phone: {type: String, es_indexed: true},
+  name: {
+    type: String,
+    es_indexed: true
+  },
+  phone: {
+    type: String,
+    es_indexed: true
+  },
   address: String,
   life: {
-    born: {type: Number, es_indexed: true},
-    died: {type: Number, es_indexed: true}
+    born: {
+      type: Number,
+      es_indexed: true
+    },
+    died: {
+      type: Number,
+      es_indexed: true
+    }
   }
 });
 
@@ -37,7 +58,11 @@ PersonSchema.plugin(mongoosastic, {
   index: 'people',
   type: 'dude',
   hydrate: true,
-  hydrateOptions: {lean: true, sort: '-name', select: 'address name life'}
+  hydrateOptions: {
+    lean: true,
+    sort: '-name',
+    select: 'address name life'
+  }
 });
 
 BumSchema.plugin(mongoosastic, {
@@ -120,7 +145,9 @@ describe('indexing', function() {
     });
 
     it('should use the model\'s id as ES id', function(done) {
-      Tweet.findOne({message: 'I like Riak better'}, function(err, doc) {
+      Tweet.findOne({
+        message: 'I like Riak better'
+      }, function(err, doc) {
         esClient.get({
           index: 'tweets',
           type: 'tweet',
@@ -193,8 +220,10 @@ describe('indexing', function() {
     });
 
     it('should report errors', function(done) {
-      Tweet.search({queriez: 'jamescarr'}, function(err, results) {
-        err.message.should.match(/SearchPhaseExecutionException/);
+      Tweet.search({
+        queriez: 'jamescarr'
+      }, function(err, results) {
+        err.message.should.match(/(SearchPhaseExecutionException|query_parsing_exception)/);
         should.not.exist(results);
         done();
       });
@@ -306,7 +335,11 @@ describe('indexing', function() {
     });
 
     it('should only find models of type Tweet', function(done) {
-      Tweet.search({query_string: {query: 'Dude'}}, function(err, res) {
+      Tweet.search({
+        query_string: {
+          query: 'Dude'
+        }
+      }, function(err, res) {
         res.hits.total.should.eql(1);
         res.hits.hits[0]._source.user.should.eql('Dude');
         done();
@@ -314,7 +347,11 @@ describe('indexing', function() {
     });
 
     it('should only find models of type Talk', function(done) {
-      Talk.search({query_string: {query: 'Dude'}}, function(err, res) {
+      Talk.search({
+        query_string: {
+          query: 'Dude'
+        }
+      }, function(err, res) {
         res.hits.total.should.eql(1);
         res.hits.hits[0]._source.title.should.eql('Dude');
         done();
@@ -332,7 +369,11 @@ describe('indexing', function() {
     });
 
     it('when gathering search results while respecting default hydrate options', function(done) {
-      Person.search({query_string: {query: 'James'}}, function(err, res) {
+      Person.search({
+        query_string: {
+          query: 'James'
+        }
+      }, function(err, res) {
         res.hits.hits[0].address.should.eql('Exampleville, MO');
         res.hits.hits[0].name.should.eql('James Carr');
         res.hits.hits[0].should.not.have.property('phone');
@@ -354,7 +395,11 @@ describe('indexing', function() {
     });
 
     it('should only return indexed fields', function(done) {
-      Talk.search({query_string: {query: 'cool'}}, function(err, res) {
+      Talk.search({
+        query_string: {
+          query: 'cool'
+        }
+      }, function(err, res) {
         var talk = res.hits.hits[0]._source;
 
         res.hits.total.should.eql(1);
@@ -368,7 +413,13 @@ describe('indexing', function() {
     });
 
     it('should hydrate returned documents if desired', function(done) {
-      Talk.search({query_string: {query: 'cool'}}, {hydrate: true}, function(err, res) {
+      Talk.search({
+        query_string: {
+          query: 'cool'
+        }
+      }, {
+        hydrate: true
+      }, function(err, res) {
         var talk = res.hits.hits[0];
 
         res.hits.total.should.eql(1);
@@ -388,12 +439,19 @@ describe('indexing', function() {
           name: 'Bob Carr',
           address: 'Exampleville, MO',
           phone: '(555)555-5555',
-          life: {born: 1950, other: 2000}
+          life: {
+            born: 1950,
+            other: 2000
+          }
         }, done);
       });
 
       it('should only return indexed fields and have indexed sub-objects', function(done) {
-        Person.search({query_string: {query: 'Bob'}}, function(err, res) {
+        Person.search({
+          query_string: {
+            query: 'Bob'
+          }
+        }, function(err, res) {
           res.hits.hits[0].address.should.eql('Exampleville, MO');
           res.hits.hits[0].name.should.eql('Bob Carr');
           res.hits.hits[0].should.have.property('life');
@@ -408,7 +466,16 @@ describe('indexing', function() {
     });
 
     it('should allow extra query options when hydrating', function(done) {
-      Talk.search({query_string: {query: 'cool'}}, {hydrate: true, hydrateOptions: {lean: true}}, function(err, res) {
+      Talk.search({
+        query_string: {
+          query: 'cool'
+        }
+      }, {
+        hydrate: true,
+        hydrateOptions: {
+          lean: true
+        }
+      }, function(err, res) {
         var talk = res.hits.hits[0];
 
         res.hits.total.should.eql(1);
@@ -433,7 +500,9 @@ describe('indexing', function() {
             mappings: {
               bum: {
                 properties: {
-                  name: {type: 'string'}
+                  name: {
+                    type: 'string'
+                  }
                 }
               }
             }
@@ -444,8 +513,14 @@ describe('indexing', function() {
 
     it('should just work', function(done) {
 
-      config.createModelAndEnsureIndex(Bum, {name: 'Roger Wilson'}, function() {
-        Bum.search({query_string: {query: 'Wilson'}}, function(err, results) {
+      config.createModelAndEnsureIndex(Bum, {
+        name: 'Roger Wilson'
+      }, function() {
+        Bum.search({
+          query_string: {
+            query: 'Wilson'
+          }
+        }, function(err, results) {
           results.hits.total.should.eql(1);
           done();
         });

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -18,7 +18,9 @@ describe('MappingGenerator', function() {
 
     it('maps field with String type attribute', function(done) {
       generator.generateMapping(new Schema({
-        name: {type: String}
+        name: {
+          type: String
+        }
       }), function(err, mapping) {
         mapping.properties.name.type.should.eql('string');
         done();
@@ -27,7 +29,10 @@ describe('MappingGenerator', function() {
 
     it('converts Date type to date', function(done) {
       generator.generateMapping(new Schema({
-        graduationDate: {type: Date, es_format: 'YYYY-MM-dd'}
+        graduationDate: {
+          type: Date,
+          es_format: 'YYYY-MM-dd'
+        }
       }), function(err, mapping) {
         mapping.properties.graduationDate.type.should.eql('date');
         done();
@@ -36,10 +41,16 @@ describe('MappingGenerator', function() {
 
     it('removes _id field without prefix', function(done) {
       generator.generateMapping(new Schema({
-        _id: {type: Schema.Types.ObjectId},
+        _id: {
+          type: Schema.Types.ObjectId
+        },
         user: {
-          _id: {type: Schema.Types.ObjectId},
-          name: {type: String}
+          _id: {
+            type: Schema.Types.ObjectId
+          },
+          name: {
+            type: String
+          }
         }
       }), function(err, mapping) {
         mapping.properties.should.not.have.property('_id');
@@ -49,10 +60,16 @@ describe('MappingGenerator', function() {
 
     it('does not remove _id field with prefix', function(done) {
       generator.generateMapping(new Schema({
-        _id: {type: Schema.Types.ObjectId},
+        _id: {
+          type: Schema.Types.ObjectId
+        },
         user: {
-          _id: {type: Schema.Types.ObjectId},
-          name: {type: String}
+          _id: {
+            type: Schema.Types.ObjectId
+          },
+          name: {
+            type: String
+          }
         }
       }), function(err, mapping) {
         mapping.properties.user.properties.should.have.property('_id');
@@ -62,7 +79,9 @@ describe('MappingGenerator', function() {
 
     it('converts object id to string if not _id', function(done) {
       generator.generateMapping(new Schema({
-        oid: {type: Schema.Types.ObjectId}
+        oid: {
+          type: Schema.Types.ObjectId
+        }
       }), function(err, mapping) {
         mapping.properties.oid.type.should.eql('string');
         done();
@@ -72,8 +91,12 @@ describe('MappingGenerator', function() {
     it('recognizes an object and maps it as one', function(done) {
       generator.generateMapping(new Schema({
         contact: {
-          email: {type: String},
-          telephone: {type: String}
+          email: {
+            type: String
+          },
+          telephone: {
+            type: String
+          }
         }
       }), function(err, mapping) {
         mapping.properties.contact.properties.email.type.should.eql('string');
@@ -84,10 +107,18 @@ describe('MappingGenerator', function() {
 
     it('recognizes an object and handles explict es_indexed', function(done) {
       generator.generateMapping(new Schema({
-        name: {type: String, es_indexed: true},
+        name: {
+          type: String,
+          es_indexed: true
+        },
         contact: {
-          email: {type: String, es_indexed: true},
-          telephone: {type: String}
+          email: {
+            type: String,
+            es_indexed: true
+          },
+          telephone: {
+            type: String
+          }
         }
       }), function(err, mapping) {
         mapping.properties.name.type.should.eql('string');
@@ -104,8 +135,14 @@ describe('MappingGenerator', function() {
           es_include_in_all: false,
           es_type: 'multi_field',
           es_fields: {
-            test: {type: 'string', index: 'analyzed'},
-            untouched: {type: 'string', index: 'not_analyzed'}
+            test: {
+              type: 'string',
+              index: 'analyzed'
+            },
+            untouched: {
+              type: 'string',
+              index: 'not_analyzed'
+            }
           }
         }
       }), function(err, mapping) {
@@ -138,8 +175,12 @@ describe('MappingGenerator', function() {
             es_type: 'geo_point',
             es_lat_lon: true
           },
-          lat: {type: Number},
-          lon: {type: Number}
+          lat: {
+            type: Number
+          },
+          lon: {
+            type: Number
+          }
         }
       }), function(err, mapping) {
         mapping.properties.geo_with_lat_lon.type.should.eql('geo_point');
@@ -150,8 +191,12 @@ describe('MappingGenerator', function() {
 
     it('recognizes an nested schema and maps it', function(done) {
       var NameSchema = new Schema({
-        first_name: {type: String},
-        last_name: {type: String}
+        first_name: {
+          type: String
+        },
+        last_name: {
+          type: String
+        }
       });
       generator.generateMapping(new Schema({
         name: [NameSchema]
@@ -165,11 +210,22 @@ describe('MappingGenerator', function() {
 
     it('recognizes an es_type of nested with es_fields and maps it', function(done) {
       var NameSchema = new Schema({
-        first_name: {type: String, es_index: 'not_analyzed'},
-        last_name: {type: String, es_index: 'not_analyzed'}
+        first_name: {
+          type: String,
+          es_index: 'not_analyzed'
+        },
+        last_name: {
+          type: String,
+          es_index: 'not_analyzed'
+        }
       });
       generator.generateMapping(new Schema({
-        name: {type: [NameSchema], es_indexed: true, es_type: 'nested', es_include_in_parent: true}
+        name: {
+          type: [NameSchema],
+          es_indexed: true,
+          es_type: 'nested',
+          es_include_in_parent: true
+        }
       }), function(err, mapping) {
         mapping.properties.name.type.should.eql('nested');
         mapping.properties.name.include_in_parent.should.eql(true);
@@ -194,7 +250,10 @@ describe('MappingGenerator', function() {
 
     it('recognizes a nested array with a simple type and additional attributes and maps it as a simple attribute', function(done) {
       generator.generateMapping(new Schema({
-        contacts: [{type: String, es_index: 'not_analyzed'}]
+        contacts: [{
+          type: String,
+          es_index: 'not_analyzed'
+        }]
       }), function(err, mapping) {
         mapping.properties.contacts.type.should.eql('string');
         mapping.properties.contacts.index.should.eql('not_analyzed');
@@ -206,7 +265,10 @@ describe('MappingGenerator', function() {
       generator.generateMapping(new Schema({
         name: String,
         contacts: [{
-          email: {type: String, es_index: 'not_analyzed'},
+          email: {
+            type: String,
+            es_index: 'not_analyzed'
+          },
           telephone: String
         }]
       }), function(err, mapping) {
@@ -220,9 +282,15 @@ describe('MappingGenerator', function() {
 
     it('excludes a virtual property from mapping', function(done) {
       var PersonSchema = new Schema({
-        first_name: {type: String},
-        last_name: {type: String},
-        age: {type: Number}
+        first_name: {
+          type: String
+        },
+        last_name: {
+          type: String
+        },
+        age: {
+          type: Number
+        }
       });
 
       PersonSchema.virtual('birthYear').set(function(year) {
@@ -244,7 +312,10 @@ describe('MappingGenerator', function() {
   describe('elastic search fields', function() {
     it('type can be overridden', function(done) {
       generator.generateMapping(new Schema({
-        name: {type: String, es_type: 'date'}
+        name: {
+          type: String,
+          es_type: 'date'
+        }
       }), function(err, mapping) {
         mapping.properties.name.type.should.eql('date');
         done();
@@ -253,7 +324,10 @@ describe('MappingGenerator', function() {
 
     it('adds the boost field', function(done) {
       generator.generateMapping(new Schema({
-        name: {type: String, es_boost: 2.2}
+        name: {
+          type: String,
+          es_boost: 2.2
+        }
       }), function(err, mapping) {
         mapping.properties.name.boost.should.eql(2.2);
         done();
@@ -262,10 +336,20 @@ describe('MappingGenerator', function() {
 
     it('respects schemas with explicit es_indexes', function(done) {
       generator.generateMapping(new Schema({
-        implicit_field_1: {type: String},
-        explicit_field_1: {type: Number, es_indexed: true},
-        implicit_field_2: {type: Number},
-        explicit_field_2: {type: String, es_indexed: true}
+        implicit_field_1: {
+          type: String
+        },
+        explicit_field_1: {
+          type: Number,
+          es_indexed: true
+        },
+        implicit_field_2: {
+          type: Number
+        },
+        explicit_field_2: {
+          type: String,
+          es_indexed: true
+        }
       }), function(err, mapping) {
         mapping.properties.should.have.property('explicit_field_1');
         mapping.properties.should.have.property('explicit_field_2');
@@ -277,8 +361,12 @@ describe('MappingGenerator', function() {
 
     it('maps all fields when schema has no es_indexed flag', function(done) {
       generator.generateMapping(new Schema({
-        implicit_field_1: {type: String},
-        implicit_field_2: {type: Number}
+        implicit_field_1: {
+          type: String
+        },
+        implicit_field_2: {
+          type: Number
+        }
       }), function(err, mapping) {
         mapping.properties.should.have.property('implicit_field_1');
         mapping.properties.should.have.property('implicit_field_2');

--- a/test/search-features-test.js
+++ b/test/search-features-test.js
@@ -7,7 +7,10 @@ var mongoose = require('mongoose'),
 
 var BondSchema = new Schema({
   name: String,
-  type: {type: String, default: 'Other Bond'},
+  type: {
+    type: String,
+    default: 'Other Bond'
+  },
   price: Number
 });
 
@@ -22,10 +25,26 @@ describe('Query DSL', function() {
       Bond.remove(function() {
         config.deleteIndexIfExists(['bonds'], function() {
           var bonds = [
-            new Bond({name: 'Bail', type: 'A', price: 10000}),
-            new Bond({name: 'Commercial', type: 'B', price: 15000}),
-            new Bond({name: 'Construction', type: 'B', price: 20000}),
-            new Bond({name: 'Legal', type: 'C', price: 30000})
+            new Bond({
+              name: 'Bail',
+              type: 'A',
+              price: 10000
+            }),
+            new Bond({
+              name: 'Commercial',
+              type: 'B',
+              price: 15000
+            }),
+            new Bond({
+              name: 'Construction',
+              type: 'B',
+              price: 20000
+            }),
+            new Bond({
+              name: 'Legal',
+              type: 'C',
+              price: 30000
+            })
           ];
           async.forEach(bonds, config.saveAndWaitIndex, function() {
             setTimeout(done, config.INDEXING_TIMEOUT);
@@ -64,7 +83,9 @@ describe('Query DSL', function() {
 
   describe('Sort', function() {
 
-    var getNames = function(res) { return res._source.name; };
+    var getNames = function(res) {
+      return res._source.name;
+    };
     var expectedDesc = ['Legal', 'Construction', 'Commercial', 'Bail'];
     var expectedAsc = expectedDesc.concat([]).reverse(); // clone and reverse
 
@@ -104,7 +125,9 @@ describe('Query DSL', function() {
           match_all: {}
         }, {
           sort: {
-            name: { order: 'asc' }
+            name: {
+              order: 'asc'
+            }
           }
         }, function(err, res) {
           res.hits.total.should.eql(4);
@@ -119,8 +142,12 @@ describe('Query DSL', function() {
           match_all: {}
         }, {
           sort: {
-            name: { order: 'desc' },
-            type: { order: 'asc' }
+            name: {
+              order: 'desc'
+            },
+            type: {
+              order: 'asc'
+            }
           }
         }, function(err, res) {
           res.hits.total.should.eql(4);
@@ -150,10 +177,22 @@ describe('Query DSL', function() {
           }
         }, function(err, res) {
           res.aggregations.names.buckets.should.eql([
-            { doc_count: 1, key: 'bail' },
-            { doc_count: 1, key: 'commercial' },
-            { doc_count: 1, key: 'construction' },
-            { doc_count: 1, key: 'legal' }
+            {
+              doc_count: 1,
+              key: 'bail'
+            },
+            {
+              doc_count: 1,
+              key: 'commercial'
+            },
+            {
+              doc_count: 1,
+              key: 'construction'
+            },
+            {
+              doc_count: 1,
+              key: 'legal'
+            }
           ]);
 
           done();
@@ -167,7 +206,9 @@ describe('Query DSL', function() {
   describe('test', function() {
 
     it('should do a fuzzy query', function(done) {
-      var getNames = function(res) { return res._source.name; };
+      var getNames = function(res) {
+        return res._source.name;
+      };
 
       Bond.search({
         match: {

--- a/test/serialize-test.js
+++ b/test/serialize-test.js
@@ -11,8 +11,14 @@ var PersonSchema22 = new Schema({
     last: String
   },
   dob: Date,
-  bowlingBall: {type: Schema.ObjectId, ref: 'BowlingBall'},
-  games: [{score: Number, date: Date}],
+  bowlingBall: {
+    type: Schema.ObjectId,
+    ref: 'BowlingBall'
+  },
+  games: [{
+    score: Number,
+    date: Date
+  }],
   somethingToCast: {
     type: String,
     es_cast: function(element) {
@@ -32,10 +38,16 @@ generator.generateMapping(PersonSchema22, function(err, tmp) {
 
 describe('serialize', function() {
   var dude = new Person({
-    name: {first: 'Jeffrey', last: 'Lebowski'},
+    name: {
+      first: 'Jeffrey',
+      last: 'Lebowski'
+    },
     dob: new Date(Date.parse('05/17/1962')),
     bowlingBall: new BowlingBall(),
-    games: [{score: 80, date: new Date(Date.parse('05/17/1962'))}, {
+    games: [{
+      score: 80,
+      date: new Date(Date.parse('05/17/1962'))
+    }, {
       score: 80,
       date: new Date(Date.parse('06/17/1962'))
     }],
@@ -44,7 +56,10 @@ describe('serialize', function() {
 
   // another person with missing parts to test robustness
   var millionnaire = new Person({
-    name: {first: 'Jeffrey', last: 'Lebowski'}
+    name: {
+      first: 'Jeffrey',
+      last: 'Lebowski'
+    }
   });
 
   it('should serialize a document with missing bits', function() {

--- a/test/suggesters-test.js
+++ b/test/suggesters-test.js
@@ -17,8 +17,15 @@ describe('Suggesters', function() {
     mongoose.connect(config.mongoUrl, function() {
       config.deleteIndexIfExists(['kittens'], function() {
         KittenSchema = new Schema({
-          name: {type: String, es_type: 'completion', es_index_analyzer: 'simple', es_search_analyzer: 'simple', es_indexed: true},
-          breed: {type: String }
+          name: {
+            type: String,
+            es_type: 'completion',
+            es_analyzer: 'simple',
+            es_indexed: true
+          },
+          breed: {
+            type: String
+          }
         });
         KittenSchema.plugin(mongoosastic);
         Kitten = mongoose.model('Kitten', KittenSchema);

--- a/test/synchronize-test.js
+++ b/test/synchronize-test.js
@@ -38,7 +38,9 @@ describe('Synchronize', function() {
 
     before(function(done) {
       async.forEach(config.bookTitlesArray(), function(title, cb) {
-        books.insert({title: title}, cb);
+        books.insert({
+          title: title
+        }, cb);
       }, done);
     });
 
@@ -53,7 +55,11 @@ describe('Synchronize', function() {
       stream.on('close', function() {
         count.should.eql(53);
         setTimeout(function() {
-          Book.search({query_string: {query: 'American'}}, function(err, results) {
+          Book.search({
+            query_string: {
+              query: 'American'
+            }
+          }, function(err, results) {
             results.hits.total.should.eql(2);
             done();
           });

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -7,8 +7,8 @@ var mongoose = require('mongoose'),
 // -- Only index specific field
 var RepoSchema = new Schema({
   name: {
-    type:String,
-    es_indexed:true
+    type: String,
+    es_indexed: true
   },
   settingLicense: {
     type: String
@@ -49,8 +49,16 @@ describe('Transform mode', function() {
   });
 
   it('should index with field "fullTitle"', function(done) {
-    config.createModelAndEnsureIndex(Repo, {name: 'LOTR', settingLicense: '', detectedLicense: 'Apache'}, function() {
-      Repo.search({query_string: {query: 'Apache'}}, function(err, results) {
+    config.createModelAndEnsureIndex(Repo, {
+      name: 'LOTR',
+      settingLicense: '',
+      detectedLicense: 'Apache'
+    }, function() {
+      Repo.search({
+        query_string: {
+          query: 'Apache'
+        }
+      }, function(err, results) {
         results.hits.total.should.eql(1);
         done();
       });

--- a/test/truncate-test.js
+++ b/test/truncate-test.js
@@ -46,14 +46,16 @@ describe('Truncate', function() {
   describe('esTruncate', function() {
     it('should be able to truncate all documents', function(done) {
       Dummy.esTruncate(function() {
-        Dummy.search({
-          query_string: {
-            query: 'Text1'
-          }
-        }, function(err, results) {
-          results.hits.total.should.eql(0);
-          done(err);
-        });
+        setTimeout(function esTruncateNextTick() {
+          Dummy.search({
+            query_string: {
+              query: 'Text1'
+            }
+          }, function(err, results) {
+            results.hits.total.should.eql(0);
+            done(err);
+          });
+        }, config.INDEXING_TIMEOUT);
       });
     });
   });


### PR DESCRIPTION
- Remove _id from bulk object. Prevent ElasticSearch to remap the _id into a string.
- Update tests to match ElasticSearch 2.x errors.
- es_index_analyzer and es_search_analyzer are merged to es_analyzer.
- Remove esTruncate since deleteByQuery was removed from native API.
- Bump elasticsearch.js from 8.x to 9.x (Default API bump from 1.7 to 2.0)