### PR TITLE
Allow for setUpMiddlewareHooks to be disabled via option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options are:
 * `bulk` - size and delay options for bulk indexing
 * `filter` - the function used for filtered indexing
 * `transform` - the function used to transform serialized document before indexing
+* `indexAutomatically` - allows indexing after model save to be disabled for when you need finer control over when documents are indexed. Defaults to true
 
 
 To have a model indexed into Elasticsearch simply add the plugin.

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -167,7 +167,8 @@ function Mongoosastic(schema, pluginOpts) {
     bulk = options && options.bulk,
     filter = options && options.filter,
     transform = options && options.transform,
-    customProperties = options && options.customProperties;
+    customProperties = options && options.customProperties,
+    indexAutomatically = options && (options.indexAutomatically === false) ? false : true;
 
   if (options.esClient) {
     esClient = options.esClient;
@@ -614,7 +615,9 @@ function Mongoosastic(schema, pluginOpts) {
     inSchema.post('findOneAndUpdate', postSave);
   }
 
-  setUpMiddlewareHooks(schema);
+  if (indexAutomatically) {
+    setUpMiddlewareHooks(schema);
+  }
 
 }
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -4,7 +4,7 @@ var mongoose = require('mongoose'),
   esClient = new elasticsearch.Client(),
   config = require('./config'),
   Schema = mongoose.Schema,
-  Person, Talk, Bum,
+  Person, Talk, Bum, Dog,
   mongoosastic = require('../lib/mongoosastic'),
   Tweet = require('./models/tweet');
 
@@ -31,6 +31,10 @@ var PersonSchema = new Schema({
   }
 });
 
+var DogSchema = new Schema({
+  name: {type: String, es_indexed: true}
+});
+
 TalkSchema.plugin(mongoosastic);
 
 PersonSchema.plugin(mongoosastic, {
@@ -45,10 +49,14 @@ BumSchema.plugin(mongoosastic, {
   type: 'bum'
 });
 
+DogSchema.plugin(mongoosastic, {
+  indexAutomatically: false
+});
+
 Person = mongoose.model('Person', PersonSchema);
 Talk = mongoose.model('Talk', TalkSchema);
 Bum = mongoose.model('bum', BumSchema);
-
+Dog = mongoose.model('dog', DogSchema);
 
 // -- alright let's test this shiznit!
 describe('indexing', function() {
@@ -453,4 +461,21 @@ describe('indexing', function() {
     });
   });
 
+  describe('Disable automatic indexing', function() {
+    it('should save but not index', function(done) {
+      var newDog = new Dog({name: 'Sparky'});
+      newDog.save(function() {
+        var whoopsIndexed = false;
+
+        newDog.on('es-indexed', function() {
+          whoopsIndexed = true;
+        });
+
+        setTimeout(function() {
+          whoopsIndexed.should.be.false();
+          done();
+        }, config.INDEXING_TIMEOUT);
+      });
+    });
+  });
 });


### PR DESCRIPTION
We are needing to index documents manually, and the async nature of the mongoose/mongoosastic events are making that harder than I want to hook into for bulk inserts, so adding an option to disable the automatic nature of saving then indexing.

Added tests and documentation.