### PR TITLE
added option to allow indexing ids

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -1,3 +1,4 @@
+/* eslint guard-for-in: 0 */
 
 //
 // Get type from the mongoose schema
@@ -121,12 +122,12 @@ function getCleanTree(tree, paths, inPrefix) {
     prefix = inPrefix !== '' ? inPrefix + '.' : inPrefix;
 
   for (field in tree) {
-    if (prefix === '' && (field === 'id' || field === '_id')) {
+    value = tree[field];
+    if (prefix === '' && (field === 'id' || field === '_id') && value.es_idIndexed !== true) {
       continue;
     }
 
     type = getTypeFromPaths(paths, prefix + field);
-    value = tree[field];
 
     if (value.es_indexed === false) {
       continue;


### PR DESCRIPTION
This will allow indexing id fields for embedded objects using `es_idIndexed` option.

Usage:

```
var articleSchema = new Schema({
    categories: [
        {
            id: { type: Number, es_idIndexed: true },
            name: String,
        }
    ]
});
```