### PR TITLE
Add builds for NodeJS 0.10 & 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: node_js
 node_js:
   - 4
   - stable
+  - 0.12
+  - 0.10
 
 services:
   - mongodb


### PR DESCRIPTION
According the package.json (`"node": ">= 0.10.0"`) we should run the tests on nodejs 0.10 and 0.12.