### PR TITLE
Add support for ElasticSearch 2.x

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -212,14 +212,14 @@ function Mongoosastic(schema, pluginOpts) {
       return;
     }
 
-    if (bulkBuffer.length >= (bulk.size || 1000)) {
+    if (bulkBuffer.length >= ((bulk && bulk.size) || 1000)) {
       schema.statics.flush();
       clearBulkTimeout();
     } else if (bulkTimeout === undefined) {
       bulkTimeout = setTimeout(function delayedBulkAdd() {
         schema.statics.flush();
         clearBulkTimeout();
-      }, bulk.delay || 1000);
+      }, (bulk && bulk.delay) || 1000);
     }
   }
 
@@ -239,7 +239,7 @@ function Mongoosastic(schema, pluginOpts) {
       index: {
         _index: opts.index || indexName,
         _type: opts.type || typeName,
-        _id: opts.model._id.toString()
+        _id: opts._id.toString()
       }
     });
     bulkAdd(opts.model);
@@ -313,15 +313,11 @@ function Mongoosastic(schema, pluginOpts) {
     if (transform) serialModel = transform(serialModel, this);
 
     if (bulk) {
-      /**
-       * To serialize in bulk it needs the _id
-       */
-
-      serialModel._id = this._id;
       bulkIndex({
         index: index,
         type: type,
-        model: serialModel
+        model: serialModel,
+        _id: this._id
       });
       setImmediate(cb);
     } else {
@@ -369,9 +365,9 @@ function Mongoosastic(schema, pluginOpts) {
    * @param cb - callback when truncation is complete
    */
   schema.statics.esTruncate = function esTruncate(inOpts, inCb) {
-    var index, type,
-      opts = inOpts,
-      cb = inCb;
+    var opts = inOpts,
+      cb = inCb,
+      esQuery;
 
     if (arguments.length < 2) {
       cb = inOpts || nop;
@@ -380,18 +376,31 @@ function Mongoosastic(schema, pluginOpts) {
 
     setIndexNameIfUnset(this.modelName);
 
-    index = opts.index || indexName;
-    type = opts.type || typeName;
+    opts.index = opts.index || indexName;
+    opts.type = opts.type || typeName;
 
-    esClient.deleteByQuery({
-      index: index,
-      type: type,
+    esQuery = {
       body: {
         query: {
           match_all: {}
         }
+      },
+      index: opts.index,
+      type: opts.type
+    };
+
+    esClient.search(esQuery, function searchCb(err, res) {
+      if (err) {
+        return cb(err);
       }
-    }, cb);
+      if (res.hits.total) {
+        res.hits.hits.forEach(function truncateEach(doc) {
+          opts.model = doc;
+          bulkDelete(opts, nop);
+        });
+      }
+      cb();
+    });
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "lib/mongoosastic.js",
   "dependencies": {
-    "elasticsearch": "^8.2.0"
+    "elasticsearch": "^10.1.3"
   },
   "devDependencies": {
     "async": "^1.4.2",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -223,7 +223,7 @@ describe('indexing', function() {
       Tweet.search({
         queriez: 'jamescarr'
       }, function(err, results) {
-        err.message.should.match(/SearchPhaseExecutionException/);
+        err.message.should.match(/(SearchPhaseExecutionException|query_parsing_exception)/);
         should.not.exist(results);
         done();
       });

--- a/test/suggesters-test.js
+++ b/test/suggesters-test.js
@@ -20,8 +20,7 @@ describe('Suggesters', function() {
           name: {
             type: String,
             es_type: 'completion',
-            es_index_analyzer: 'simple',
-            es_search_analyzer: 'simple',
+            es_analyzer: 'simple',
             es_indexed: true
           },
           breed: {

--- a/test/truncate-test.js
+++ b/test/truncate-test.js
@@ -46,14 +46,16 @@ describe('Truncate', function() {
   describe('esTruncate', function() {
     it('should be able to truncate all documents', function(done) {
       Dummy.esTruncate(function() {
-        Dummy.search({
-          query_string: {
-            query: 'Text1'
-          }
-        }, function(err, results) {
-          results.hits.total.should.eql(0);
-          done(err);
-        });
+        setTimeout(function esTruncateNextTick() {
+          Dummy.search({
+            query_string: {
+              query: 'Text1'
+            }
+          }, function(err, results) {
+            results.hits.total.should.eql(0);
+            done(err);
+          });
+        }, config.INDEXING_TIMEOUT);
       });
     });
   });


### PR DESCRIPTION
- Remove _id from bulk object. Prevent ElasticSearch to remap the _id into a string.
- Update tests to match ElasticSearch 2.x errors.
- es_index_analyzer and es_search_analyzer are merged to es_analyzer.
- Refactor esTruncate since deleteByQuery was removed from native API.
- Bump elasticsearch.js from 8.x to 10.x (Default API bump from 1.7 to 2.1)