### PR TITLE
Fixes #39 - dont modify schema

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -169,7 +169,12 @@ function getCleanTree(tree, paths, inPrefix) {
         cleanTree[field] = {};
         cleanTree[field].type = type;
       } else {
-        cleanTree[field] = value;
+        cleanTree[field] = {};
+        for (key in value) {
+          if (value.hasOwnProperty(key)) {
+            cleanTree[field][key] = value[key];
+          }
+        }
         cleanTree[field].type = type;
       }
 

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -88,6 +88,18 @@ describe('MappingGenerator', function() {
       });
     });
 
+    it('does not modify the original schema tree', function(done) {
+      var schema = new Schema({
+        oid: Schema.ObjectId
+      });
+
+      generator.generateMapping(schema, function(err, mapping) {
+        mapping.properties.oid.type.should.eql('string');
+        should.not.exist(schema.tree.oid.type);
+        done();
+      });
+    });
+
     it('recognizes an object and maps it as one', function(done) {
       generator.generateMapping(new Schema({
         contact: {


### PR DESCRIPTION
Previously, when generating a clean tree in the mapping generator, the original schema was being modified in certain situations.  This was causing the problem in #39.  This pull fixes that.