### PR TITLE
Using postSave(doc) instead of doc.save(cb) in .synchronize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ var stream = Book.synchronize({}, {saveOnSynchronize: true})
 
 Options are:
 
- * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to false
+ * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to false (or global `saveOnSynchronize`)
 
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Options are:
 * `transform` - the function used to transform serialized document before indexing
 * `populate` - an Array of Mongoose populate options objects
 * `indexAutomatically` - allows indexing after model save to be disabled for when you need finer control over when documents are indexed. Defaults to true
-* `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to false
+* `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to true
 
 
 To have a model indexed into Elasticsearch simply add the plugin.
@@ -276,7 +276,7 @@ var stream = Book.synchronize({}, {saveOnSynchronize: true})
 
 Options are:
 
- * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to false (or global `saveOnSynchronize`)
+ * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to global `saveOnSynchronize` option
 
 
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Options are:
 * `transform` - the function used to transform serialized document before indexing
 * `populate` - an Array of Mongoose populate options objects
 * `indexAutomatically` - allows indexing after model save to be disabled for when you need finer control over when documents are indexed. Defaults to true
+* `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to false
 
 
 To have a model indexed into Elasticsearch simply add the plugin.
@@ -153,7 +154,7 @@ doc.save(function(err){
 ```
 
 
-###Indexing Nested Models
+### Indexing Nested Models
 In order to index nested models you can refer following example.
 
 ```javascript
@@ -174,7 +175,7 @@ var User = new Schema({
 User.plugin(mongoosastic)
 ```
 
-###Elasticsearch [Nested datatype](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/nested.html)
+### Elasticsearch [Nested datatype](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/nested.html)
 Since the default in Elasticsearch is to take arrays and flatten them into objects,
 it can make it hard to write queries where you need to maintain the relationships 
 between objects in the array, per .
@@ -204,7 +205,7 @@ var User = new Schema({
 User.plugin(mongoosastic)
 ```
 
-###Indexing Mongoose References
+### Indexing Mongoose References
 In order to index mongoose references you can refer following example.
 
 ```javascript
@@ -267,6 +268,18 @@ You can also synchronize a subset of documents based on a query!
 var stream = Book.synchronize({author: 'Arthur C. Clarke'})
 ```
 
+As well as specifying synchronization options
+
+```javascript
+var stream = Book.synchronize({}, {saveOnSynchronize: true})
+```
+
+Options are:
+
+ * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to false
+
+
+
 ### Bulk Indexing
 
 You can also specify `bulk` options with mongoose which will utilize Elasticsearch's bulk indexing api. This will cause the `synchronize` function to use bulk indexing as well. 
@@ -328,7 +341,7 @@ mongodb. Use save for that.
 
 ### Truncating an index
 
-The static method `esTruncate` will delete all documents from the associated index. This method combined with synchronise can be usefull in case of integration tests for example when each test case needs a cleaned up index in Elasticsearch.
+The static method `esTruncate` will delete all documents from the associated index. This method combined with `synchronize()` can be useful in case of integration tests for example when each test case needs a cleaned up index in Elasticsearch.
 
 ```javascript
 GarbageModel.esTruncate(function(err){...});

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -180,7 +180,8 @@ function Mongoosastic(schema, pluginOpts) {
     filter = options && options.filter,
     transform = options && options.transform,
     customProperties = options && options.customProperties,
-    indexAutomatically = options && (options.indexAutomatically === false) ? false : true;
+    indexAutomatically = options && (options.indexAutomatically === false) ? false : true,
+    saveOnSynchronize = options && (options.saveOnSynchronize === false) ? false : true;
 
   if (options.esClient) {
     esClient = options.esClient;
@@ -423,12 +424,13 @@ function Mongoosastic(schema, pluginOpts) {
    *
    * @param query - query for documents you want to synchronize
    */
-  schema.statics.synchronize = function synchronize(inQuery) {
+  schema.statics.synchronize = function synchronize(inQuery, inOpts) {
     var em = new events.EventEmitter(),
       closeValues = [],
       counter = 0,
       stream,
       query = inQuery || {},
+      _saveOnSynchronize = inOpts && (inOpts.saveOnSynchronize === false) ? false : true,
       close = function close() {
         em.emit.apply(em, ['close'].concat(closeValues));
       };
@@ -461,7 +463,19 @@ function Mongoosastic(schema, pluginOpts) {
       doc.on('es-indexed', onIndex);
       doc.on('es-filtered', onIndex);
 
-      postSave(doc);
+      if (_saveOnSynchronize) {
+        // Save document with Mongoose first
+        doc.save(function onSave(err) {
+          if (err) {
+            em.emit('error', err);
+            return stream.resume();
+          }
+        });
+      } else {
+
+        postSave(doc);
+      }
+
     });
 
     stream.on('close', function onClose(pA, pB) {

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -437,12 +437,7 @@ function Mongoosastic(schema, pluginOpts) {
       doc.on('es-indexed', onIndex);
       doc.on('es-filtered', onIndex);
 
-      doc.save(function onSave(err) {
-        if (err) {
-          em.emit('error', err);
-          return stream.resume();
-        }
-      });
+      postSave(doc);
     });
 
     stream.on('close', function onClose(pA, pB) {

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -643,4 +643,3 @@ function Mongoosastic(schema, pluginOpts) {
 }
 
 module.exports = Mongoosastic;
-

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -198,6 +198,29 @@ function Mongoosastic(schema, pluginOpts) {
     }
   }
 
+  function postSave(doc) {
+    function onIndex(err, res) {
+      if (!filter || !filter(doc)) {
+        doc.emit('es-indexed', err, res);
+      } else {
+        doc.emit('es-filtered', err, res);
+      }
+    }
+
+    if (doc) {
+      if (populate && populate.length) {
+        populate.forEach(function (populateOpts) {
+          doc.populate(populateOpts);
+        });
+        doc.execPopulate().then(function (popDoc) {
+          popDoc.index(onIndex);
+        });
+      } else {
+        doc.index(onIndex);
+      }
+    }
+  }
+
   function clearBulkTimeout() {
     clearTimeout(bulkTimeout);
     bulkTimeout = undefined;
@@ -594,29 +617,6 @@ function Mongoosastic(schema, pluginOpts) {
       bulkDelete(opts, nop);
     } else {
       deleteByMongoId(opts, nop);
-    }
-  }
-
-  function postSave(doc) {
-    function onIndex(err, res) {
-      if (!filter || !filter(doc)) {
-        doc.emit('es-indexed', err, res);
-      } else {
-        doc.emit('es-filtered', err, res);
-      }
-    }
-
-    if (doc) {
-      if (populate && populate.length) {
-        populate.forEach(function (populateOpts) {
-          doc.populate(populateOpts);
-        });
-        doc.execPopulate().then(function (popDoc) {
-          popDoc.index(onIndex);
-        });
-      } else {
-        doc.index(onIndex);
-      }
     }
   }
 

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -179,7 +179,7 @@ function Mongoosastic(schema, pluginOpts) {
     transform = options && options.transform,
     customProperties = options && options.customProperties,
     indexAutomatically = !(options && options.indexAutomatically === false),
-    saveOnSynchronize = options && (options.saveOnSynchronize === true) ? true : false;
+    saveOnSynchronize = options && options.saveOnSynchronize;
 
   if (options.esClient) {
     esClient = options.esClient;

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -181,7 +181,7 @@ function Mongoosastic(schema, pluginOpts) {
     transform = options && options.transform,
     customProperties = options && options.customProperties,
     indexAutomatically = options && (options.indexAutomatically === false) ? false : true,
-    saveOnSynchronize = options && (options.saveOnSynchronize === false) ? false : true;
+    saveOnSynchronize = options && (options.saveOnSynchronize === true) ? true : false;
 
   if (options.esClient) {
     esClient = options.esClient;
@@ -430,10 +430,12 @@ function Mongoosastic(schema, pluginOpts) {
       counter = 0,
       stream,
       query = inQuery || {},
-      _saveOnSynchronize = inOpts && (inOpts.saveOnSynchronize === false) ? false : true,
+      _saveOnSynchronize,
       close = function close() {
         em.emit.apply(em, ['close'].concat(closeValues));
       };
+
+    _saveOnSynchronize = inOpts && inOpts.saveOnSynchronize !== undefined ? inOpts.saveOnSynchronize : saveOnSynchronize;
 
     // Set indexing to be bulk when synchronizing to make synchronizing faster
     // Set default values when not present

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -643,3 +643,4 @@ function Mongoosastic(schema, pluginOpts) {
 }
 
 module.exports = Mongoosastic;
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "James R. Carr <james.r.carr@gmail.com> (http://blog.james-carr.org)",
   "name": "mongoosastic",
   "description": "A mongoose plugin that indexes models into elastic search",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "tags": [
     "mongodb",
     "elasticsearch",


### PR DESCRIPTION
Previously a `doc.save()` was triggered for synchronizing doc instance to ElasticSearch.

It means that before indexing doc instance to ElasticSearch, mongoose will process all pre-save hooks of the doc model.

It is undesirable since:
 * depending on the situation, some pre-save's can be costly
 * some pre-save methods can fail, thus the document is not indexed

PR replaces `doc.save(cb)` by `postSave(doc)`

Unit tests OK. Tested in production.