### PR TITLE
Hydrated results are augmented with the raw ES result: useful for retrieving score

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,8 +580,11 @@ provide {hydrate:true} as the second argument to a search call.
 
 ```javascript
 
-User.search({query_string: {query: "john"}}, {hydrate:true}, function(err, results) {
-  // results here
+User.search(
+  {query_string: {query: 'john'}},
+  {hydrate: true},
+  function(err, results) {
+    // results here
 });
 
 ```
@@ -591,11 +594,46 @@ how to query for the mongoose object.
 
 ```javascript
 
-User.search({query_string: {query: "john"}}, {hydrate:true, hydrateOptions: {select: 'name age'}}, function(err, results) {
-  // results here
+User.search(
+  {query_string: {query: 'john'}},
+  {
+    hydrate: true,
+    hydrateOptions: {select: 'name age'}
+  },
+  function(err, results) {
+    // results here
 });
 
 ```
+
+Original ElasticSearch result data can be kept with `hydrateWithESResults` option. Documents are then enhanced with a
+`_esResult` property
+
+```javascript
+
+User.search(
+  {query_string: {query: 'john'}},
+  {
+    hydrate: true,
+    hydrateWithESResults: true,
+    hydrateOptions: {select: 'name age'}
+  },
+  function(err, results) {
+    // results here
+    results.hits.hits.forEach(function(result) {
+      console.log(
+        'score',
+        result._id,
+        result._esResult._score
+      );
+    });
+});
+
+```
+
+By default the `_esResult._source` document is skipped. It can be added with the option `hydrateWithESResults: {source: false}`.
+
+
 
 Note using hydrate will be a degree slower as it will perform an Elasticsearch
 query and then do a query against mongodb for all the ids returned from

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -130,6 +130,15 @@ function hydrate(res, model, options, cb) {
         doc._highlight = results.hits[idx].highlight;
       }
 
+      if (options.hydrateWithESResults) {
+        // Add to doc ES raw result (with, e.g., _score value)
+        doc._esResult = results.hits[idx];
+        if (!options.hydrateWithESResults.source) {
+          // Remove heavy load
+          delete doc._esResult._source;
+        }
+      }
+
       hits[idx] = doc;
     });
 

--- a/test/hydrate-with-es-results-test.js
+++ b/test/hydrate-with-es-results-test.js
@@ -1,0 +1,161 @@
+var mongoose = require('mongoose'),
+    async = require('async'),
+    config = require('./config'),
+    Schema = mongoose.Schema,
+    esResultText,
+    mongoosastic = require('../lib/mongoosastic');
+
+var esResultTextSchema = new Schema({
+  title: String,
+  quote: String
+});
+
+esResultTextSchema.plugin(mongoosastic);
+
+esResultText = mongoose.model('esResultText', esResultTextSchema);
+
+describe('Hydrate with ES data', function() {
+  var responses = [
+    'You don\'t see people at their best in this job, said <em>Death</em>.',
+    'The <em>death</em> of the warrior or the old man or the little child, this I understand, and I take away the',
+    ' pain and end the suffering. I do not understand this <em>death</em>-of-the-mind',
+    'The only reason for walking into the jaws of <em>Death</em> is so\'s you can steal his gold teeth'
+  ];
+
+  before(function(done) {
+    mongoose.connect(config.mongoUrl, function() {
+      esResultText.remove(function() {
+        config.deleteIndexIfExists(['esresulttexts'], function() {
+
+          // Quotes are from Terry Pratchett's Discworld books
+          var esResultTexts = [
+            new esResultText({
+              title: 'The colour of magic',
+              quote: 'The only reason for walking into the jaws of Death is so\'s you can steal his gold teeth'
+            }),
+            new esResultText({
+              title: 'The Light Fantastic',
+              quote: 'The death of the warrior or the old man or the little child, this I understand, and I take ' +
+              'away the pain and end the suffering. I do not understand this death-of-the-mind'
+            }),
+            new esResultText({
+              title: 'Equal Rites',
+              quote: 'Time passed, which, basically, is its job'
+            }),
+            new esResultText({
+              title: 'Mort',
+              quote: 'You don\'t see people at their best in this job, said Death.'
+            })
+          ];
+          async.forEach(esResultTexts, config.saveAndWaitIndex, function() {
+            setTimeout(done, config.INDEXING_TIMEOUT);
+          });
+        });
+      });
+    });
+  });
+
+  after(function(done) {
+    esResultText.remove();
+    esResultText.esClient.close();
+    mongoose.disconnect();
+    done();
+  });
+
+  describe('Hydrate without adding ES data', function() {
+    it('should return simple objects', function(done) {
+
+      esResultText.search({
+        match_phrase: {
+          quote: 'Death'
+        }
+      }, {
+        hydrate: true
+      }, function(err, res) {
+
+        res.hits.total.should.eql(3);
+        res.hits.hits.forEach(function(text) {
+          text.should.not.have.property('_esResult');
+        });
+
+        done();
+      });
+    });
+
+  });
+
+  describe('Hydrate and add ES data', function() {
+    it('should return object enhanced with _esResult', function(done) {
+
+      esResultText.search({
+        match_phrase: {
+          quote: 'Death'
+        }
+      }, {
+        hydrate: true,
+        hydrateWithESResults: true,
+        highlight: {
+          fields: {
+            quote: {}
+          }
+        }
+      }, function(err, res) {
+
+        res.hits.total.should.eql(3);
+        res.hits.hits.forEach(function(model) {
+            
+          model.should.have.property('_esResult');
+          model._esResult.should.have.property('_index');
+          model._esResult._index.should.eql('esresulttexts');
+          model._esResult.should.have.property('_type');
+          model._esResult._type.should.eql('esresulttext');
+          model._esResult.should.have.property('_id');
+          model._esResult.should.have.property('_score');
+          model._esResult.should.have.property('highlight');
+
+          model._esResult.should.not.have.property('_source');
+        });
+
+        done();
+      });
+    });
+
+    it('should remove _source object', function (done) {
+
+      esResultText.search({
+        match_phrase: {
+          quote: 'Death'
+        }
+      }, {
+        hydrate: true,
+        hydrateWithESResults: {source: true},
+        highlight: {
+          fields: {
+            quote: {}
+          }
+        }
+      }, function(err, res) {
+
+        res.hits.total.should.eql(3);
+        res.hits.hits.forEach(function(model) {
+
+          model.should.have.property('_esResult');
+          model._esResult.should.have.property('_index');
+          model._esResult._index.should.eql('esresulttexts');
+          model._esResult.should.have.property('_type');
+          model._esResult._type.should.eql('esresulttext');
+          model._esResult.should.have.property('_id');
+          model._esResult.should.have.property('_score');
+          model._esResult.should.have.property('highlight');
+
+          model._esResult.should.have.property('_source');
+          model._esResult._source.should.have.property('title');
+          model._esResult._source.should.have.property('title');
+        });
+
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
On hydration, adds an option `hydrateWithESResults`
 * `true`: hydrated result are augmented with a _.esResult containing non-hydrated search ES result, `._source`property is removed by default
 * `{source: true}`: `._source`property is returned too 

Doing so, score value is not lost.

```js
User.search(
  {query_string: {query: 'john'}},
  {
    hydrate: true,
    hydrateWithESResults: true,
    hydrateOptions: {select: 'name age'}
  },
  function(err, results) {
    // results here
    results.hits.hits.forEach(function(result) {
      console.log(
        'score',
        result._id,
        result._esResult._score
      );
    });
});
```