### PR TITLE
added: skipping mongoose validation when synchronize

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -402,7 +402,7 @@ function Mongoosastic(schema, pluginOpts) {
    *
    * @param query - query for documents you want to synchronize
    */
-  schema.statics.synchronize = function synchronize(inQuery) {
+  schema.statics.synchronize = function synchronize(inQuery, skipValidation) {
     var em = new events.EventEmitter(),
       closeValues = [],
       counter = 0,
@@ -410,7 +410,8 @@ function Mongoosastic(schema, pluginOpts) {
       query = inQuery || {},
       close = function close() {
         em.emit.apply(em, ['close'].concat(closeValues));
-      };
+      },
+      saveOptions = {};
 
     // Set indexing to be bulk when synchronizing to make synchronizing faster
     // Set default values when not present
@@ -439,8 +440,8 @@ function Mongoosastic(schema, pluginOpts) {
 
       doc.on('es-indexed', onIndex);
       doc.on('es-filtered', onIndex);
-
-      doc.save(err => {
+      saveOptions = skipValidation ? { validateBeforeSave: false } : {};
+      doc.save(saveOptions, err => {
         if (err) {
           em.emit('error', err);
           return stream.resume();


### PR DESCRIPTION
When using complex schemas it can be a pain to validate every document before indexing it. 