### PR TITLE
It's now possible to use "type" as model property

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -50,7 +50,7 @@ function getMapping(cleanTree, inPrefix) {
     mapping[field].type = value.type;
 
     // Check if field was explicity indexed, if not keep track implicitly
-    if (value.es_indexed) {
+    if (value.es_indexed || (typeof(value.type) === 'object' && value.type.es_indexed === true)) {
       hasEsIndex = true;
     } else if (value.type) {
       implicitFields.push(field);
@@ -252,6 +252,7 @@ Generator.prototype.generateMapping = function generateMapping(schema, cb) {
     mapping;
   delete cleanTree[schema.get('versionKey')];
   mapping = getMapping(cleanTree, '');
+  
   cb(null, {
     properties: mapping
   });

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -319,6 +319,33 @@ describe('MappingGenerator', function() {
         done();
       });
     });
+
+    it('recognizes "type" as field when "type" is defined a model property (it needs es_indexed)', function(done) {
+      generator.generateMapping(new Schema({
+        type: {
+          type:String,
+          es_indexed: true
+        }
+      }), function(err, mapping) {
+        mapping.properties.type.type.should.eql('string')
+        done();
+      });
+    });
+
+    it.only('recognizes when "type" in an array', function(done) {
+      generator.generateMapping(new Schema({
+        entities: [{
+          type: {
+            type:String,
+            es_indexed: true
+          }
+        }]
+      }), function(err, mapping) {
+        console.log(mapping.properties)
+        done();
+      });
+    });
+
   });
 
   describe('elastic search fields', function() {

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -332,7 +332,7 @@ describe('MappingGenerator', function() {
       });
     });
 
-    it.only('recognizes when "type" in an array', function(done) {
+    it('recognizes when "type" in an array', function(done) {
       generator.generateMapping(new Schema({
         entities: [{
           type: {


### PR DESCRIPTION
Having some "type" properties in my mongodb documents I did a little amend (with tests) in the mapping generator to support "type" as property name.