### PR TITLE
Fix explicit es_indexed on array

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -141,7 +141,7 @@ function getCleanTree(tree, paths, inPrefix) {
     // Field has some kind of type
     if (type) {
       // If it is an nested schema
-      if (value[0]) {
+      if (value[0] || type === 'embedded') {
         // A nested array can contain complex objects
         nestedSchema(paths, field, cleanTree, value, prefix); // eslint-disable-line no-use-before-define
       } else if (value.type && Array.isArray(value.type)) {

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -150,7 +150,7 @@ function getCleanTree(tree, paths, inPrefix) {
         // Merge top level es settings
         for (prop in value) {
           // Map to field if it's an Elasticsearch option
-          if (value.hasOwnProperty(prop) && prop.indexOf('es_') === 0 && prop !== 'es_indexed') {
+          if (value.hasOwnProperty(prop) && prop.indexOf('es_') === 0) {
             cleanTree[field][prop] = value[prop];
           }
         }

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -361,12 +361,21 @@ describe('MappingGenerator', function() {
         explicit_field_2: {
           type: String,
           es_indexed: true
+        },
+        implicit_field_3: {
+          type: [Number]
+        },
+        explicit_field_3: {
+          type: [Number],
+          es_indexed: true
         }
       }), function(err, mapping) {
         mapping.properties.should.have.property('explicit_field_1');
         mapping.properties.should.have.property('explicit_field_2');
+        mapping.properties.should.have.property('explicit_field_3');
         mapping.properties.should.not.have.property('implicit_field_1');
         mapping.properties.should.not.have.property('implicit_field_2');
+        mapping.properties.should.not.have.property('implicit_field_3');
         done();
       });
     });

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -130,12 +130,55 @@ describe('MappingGenerator', function() {
           },
           telephone: {
             type: String
+          },
+          keys: [String],
+          tags: {
+            type: [String],
+            es_indexed: true
           }
         }
       }), function(err, mapping) {
         mapping.properties.name.type.should.eql('string');
         mapping.properties.contact.properties.email.type.should.eql('string');
+        mapping.properties.contact.properties.tags.type.should.eql('string');
         mapping.properties.contact.properties.should.not.have.property('telephone');
+        mapping.properties.contact.properties.should.not.have.property('keys');
+        done();
+      });
+    });
+
+    it('recognizes a nested schema and handles explict es_indexed', function(done) {
+
+      var ContactSchema = new Schema({
+        email: {
+          type: String,
+          es_indexed: true
+        },
+        telephone: {
+          type: String
+        },
+        keys: {type: [String], es_indexed: false},
+        tags: {
+          type: [String],
+          es_indexed: true
+        }
+      });
+
+      generator.generateMapping(new Schema({
+        name: {
+          type: String,
+          es_indexed: true
+        },
+        contact: {
+          type: ContactSchema,
+          select: false
+        }
+      }), function(err, mapping) {
+        mapping.properties.name.type.should.eql('string');
+        mapping.properties.contact.properties.email.type.should.eql('string');
+        mapping.properties.contact.properties.tags.type.should.eql('string');
+        mapping.properties.contact.properties.should.not.have.property('telephone');
+        mapping.properties.contact.properties.should.not.have.property('keys');
         done();
       });
     });


### PR DESCRIPTION
I guess this fix will address a few people which, like me, use legacy geo point.
Using this kind of schema:

    var UserSchema = new mongoose.Schema({
      firstname: {type: String, es_indexed: true},
      lastname: {type: String, es_indexed: true},

      phone: {type: phoneNumberSchemaRaw, select: false},
      email: { type: String, lowercase: true, select: false},
      geo: {
        type: [Number],
        index: '2dsphere',
        select: false,
        es_indexed: true,
        es_type: 'geo_point'
      }

    });

Only firstname & lastname where sent to elasticsearch