### PR TITLE
fix a bug where calling doc.index would overwrite all plugin options!

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -288,7 +288,7 @@ function Mongoosastic(schema, pluginOpts) {
 
     if (arguments.length < 2) {
       cb = inOpts || nop;
-      options = {};
+      opts = {};
     }
 
     if (filter && filter(this)) {


### PR DESCRIPTION
The `inOpts` argument was being assigned to the plugins' `options` when re-assigning args.
Discovered this when trying to `.synchronize` more than one model.
