### PR TITLE
Hydration now preserves ES ordering (if no hydrateOptions.sort is set)

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -117,28 +117,47 @@ function hydrate(res, model, options, cb) {
   });
 
   query.exec((err, docs) => {
-    var hits = [];
+    var hits,
+      docsMap = {};
+
     if (err) {
       return cb(err);
     }
 
-    docs.forEach(doc => {
-      var idx = resultsMap[doc._id];
-      if (options.highlight) {
-        doc._highlight = results.hits[idx].highlight;
-      }
+    if (!docs || docs.length === 0) {
+      results.hits = [];
+      res.hits = results;
+      return cb(null, res);
+    }
 
-      if (options.hydrateWithESResults) {
-        // Add to doc ES raw result (with, e.g., _score value)
-        doc._esResult = results.hits[idx];
-        if (!options.hydrateWithESResults.source) {
-          // Remove heavy load
-          delete doc._esResult._source;
+    if (hydrateOptions.sort) {
+      // Hydrate sort has precedence over ES result order
+      hits = docs;
+    } else {
+      // Preserve ES result ordering
+      docs.forEach(doc => {
+        docsMap[doc._id] = doc;
+      });
+      hits = results.hits.map(result => docsMap[result._id]);
+    }
+
+    if (options.highlight || options.hydrateWithESResults) {
+      hits.forEach(doc => {
+        var idx = resultsMap[doc._id];
+        if (options.highlight) {
+          doc._highlight = results.hits[idx].highlight;
         }
-      }
+        if (options.hydrateWithESResults) {
+          // Add to doc ES raw result (with, e.g., _score value)
+          doc._esResult = results.hits[idx];
+          if (!options.hydrateWithESResults.source) {
+            // Remove heavy load
+            delete doc._esResult._source;
+          }
+        }
 
-      hits[idx] = doc;
-    });
+      });
+    }
 
     results.hits = hits;
     res.hits = results;
@@ -284,8 +303,8 @@ function Mongoosastic(schema, pluginOpts) {
   schema.statics.esClient = esClient;
 
   /**
-   * Create the mapping. Takes an optional settings parameter and a callback that will be called once
-   * the mapping is created
+   * Create the mapping. Takes an optional settings parameter
+   * and a callback that will be called once the mapping is created
 
    * @param settings Object (optional)
    * @param cb Function
@@ -446,7 +465,8 @@ function Mongoosastic(schema, pluginOpts) {
         em.emit.apply(em, ['close'].concat(closeValues));
       };
 
-    _saveOnSynchronize = inOpts && inOpts.saveOnSynchronize !== undefined ? inOpts.saveOnSynchronize : saveOnSynchronize;
+    _saveOnSynchronize = inOpts &&
+      inOpts.saveOnSynchronize !== undefined ? inOpts.saveOnSynchronize : saveOnSynchronize;
 
     // Set indexing to be bulk when synchronizing to make synchronizing faster
     // Set default values when not present

--- a/test/hydrate-preserves-ordering-test.js
+++ b/test/hydrate-preserves-ordering-test.js
@@ -1,0 +1,150 @@
+var mongoose = require('mongoose'),
+    async = require('async'),
+    config = require('./config'),
+    Schema = mongoose.Schema,
+    rankModel,
+    mongoosastic = require('../lib/mongoosastic');
+
+var rankSchema = new Schema({
+  title: String,
+  rank: Number
+});
+
+rankSchema.plugin(mongoosastic);
+
+rankModel = mongoose.model('rank', rankSchema);
+
+describe('Hydrate with ES data', function() {
+
+  before(function(done) {
+    mongoose.connect(config.mongoUrl, function() {
+      rankModel.remove(function() {
+        config.deleteIndexIfExists(['ranks'], function() {
+
+          // Quotes are from Terry Pratchett's Discworld books
+          var esResultTexts = [
+            new rankModel({
+              title: 'The colour of magic',
+              rank: 2
+            }),
+            new rankModel({
+              title: 'The Light Fantastic',
+              rank: 4
+            }),
+            new rankModel({
+              title: 'Equal Rites',
+              rank: 0
+            }),
+            new rankModel({
+              title: 'MorzartEstLà',
+              rank: -10.4
+            })
+          ];
+          async.forEach(esResultTexts, config.saveAndWaitIndex, function() {
+            setTimeout(done, config.INDEXING_TIMEOUT);
+          });
+        });
+      });
+    });
+  });
+
+  after(function(done) {
+    rankModel.remove();
+    rankModel.esClient.close();
+    mongoose.disconnect();
+    done();
+  });
+
+  describe('Preserve ordering from MongoDB on hydration', function() {
+    it('should return an array of objects ordered \'desc\' by MongoDB', function(done) {
+
+      rankModel.esSearch({}, {
+        hydrate: true,
+        hydrateOptions: {sort: '-rank'}
+      }, function (err, res) {
+        if (err) done(err);
+
+        res.hits.total.should.eql(4);
+        res.hits.hits[0].rank.should.eql(4);
+        res.hits.hits[1].rank.should.eql(2);
+        res.hits.hits[2].rank.should.eql(0);
+        res.hits.hits[3].rank.should.eql(-10.4);
+
+        done();
+      });
+    });
+
+  });
+
+  describe('Preserve ordering from MongoDB on hydration', function() {
+    it('should return an array of objects ordered \'asc\' by MongoDB', function(done) {
+
+      rankModel.esSearch({}, {
+        hydrate: true,
+        hydrateOptions: {sort: 'rank'}
+      }, function (err, res) {
+        if (err) done(err);
+
+        res.hits.total.should.eql(4);
+        res.hits.hits[0].rank.should.eql(-10.4);
+        res.hits.hits[1].rank.should.eql(0);
+        res.hits.hits[2].rank.should.eql(2);
+        res.hits.hits[3].rank.should.eql(4);
+
+        done();
+      });
+    });
+
+  });
+
+  describe('Preserve ordering from ElasticSearch on hydration', function() {
+      it('should return an array of objects ordered \'desc\' by ES', function (done) {
+
+          rankModel.esSearch({
+              sort: [{
+                  rank: {
+                      order: 'desc'
+                  }
+              }]
+          }, {
+              hydrate: true,
+              hydrateOptions: {sort: undefined}
+          }, function (err, res) {
+              if (err) done(err);
+              res.hits.total.should.eql(4);
+              res.hits.hits[0].rank.should.eql(4);
+              res.hits.hits[1].rank.should.eql(2);
+              res.hits.hits[2].rank.should.eql(0);
+              res.hits.hits[3].rank.should.eql(-10.4);
+
+              done();
+          });
+      });
+  });
+
+  describe('Preserve ordering from ElasticSearch on hydration', function() {
+    it('should return an array of objects ordered \'asc\' by ES', function(done) {
+
+      rankModel.esSearch({
+        sort: [{
+            rank: {
+              order: 'asc'
+          }
+        }]
+      }, {
+        hydrate: true,
+        hydrateOptions: {sort: undefined}
+      }, function (err, res) {
+        if (err) done(err);
+        res.hits.total.should.eql(4);
+        res.hits.hits[0].rank.should.eql(-10.4);
+        res.hits.hits[1].rank.should.eql(0);
+        res.hits.hits[2].rank.should.eql(2);
+        res.hits.hits[3].rank.should.eql(4);
+
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
The hydration step was destroying the ordering of results created by ElasticSearch.

Hydration relies on $in operator of MongoDB/Mongoose and it does not return the documents in the same order as in the $in argument (long open 'bug' in MongoDB: https://jira.mongodb.org/browse/SERVER-7528).

This PR ensures that
 * if hydration 'sort' option is set, then hydration sort has precedence over ES ranking: ordering is controlled by MongoDB through hydrate 'sort' option
 * if no hydration 'sort' is set, Mongoosastic preserves ES ranking