### PR TITLE
Bis: Using postSave(doc) instead of doc.save(cb) in .synchronize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options are:
 * `populate` - an Array of Mongoose populate options objects
 * `indexAutomatically` - allows indexing after model save to be disabled for when you need finer control over when documents are indexed. Defaults to true
 * `customProperties` - an object detailing additional properties which will be merged onto the type's default mapping when `createMapping` is called.
+* `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to true
 
 
 To have a model indexed into Elasticsearch simply add the plugin.
@@ -178,7 +179,7 @@ MyModel.remove({ _id: doc.id }, function(err) {
 });
 ```
 
-###Indexing Nested Models
+### Indexing Nested Models
 In order to index nested models you can refer following example.
 
 ```javascript
@@ -199,7 +200,7 @@ var User = new Schema({
 User.plugin(mongoosastic)
 ```
 
-###Elasticsearch [Nested datatype](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/nested.html)
+### Elasticsearch [Nested datatype](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/nested.html)
 Since the default in Elasticsearch is to take arrays and flatten them into objects,
 it can make it hard to write queries where you need to maintain the relationships
 between objects in the array, per .
@@ -229,7 +230,7 @@ var User = new Schema({
 User.plugin(mongoosastic)
 ```
 
-###Indexing Mongoose References
+### Indexing Mongoose References
 In order to index mongoose references you can refer following example.
 
 ```javascript
@@ -291,6 +292,17 @@ You can also synchronize a subset of documents based on a query!
 ```javascript
 var stream = Book.synchronize({author: 'Arthur C. Clarke'})
 ```
+
+As well as specifying synchronization options
+
+```javascript
+var stream = Book.synchronize({}, {saveOnSynchronize: true})
+```
+
+Options are:
+
+ * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to global `saveOnSynchronize` option
+
 
 ### Bulk Indexing
 
@@ -370,7 +382,7 @@ The unIndex method takes 2 arguments:
 
 ### Truncating an index
 
-The static method `esTruncate` will delete all documents from the associated index. This method combined with synchronise can be usefull in case of integration tests for example when each test case needs a cleaned up index in Elasticsearch.
+The static method `esTruncate` will delete all documents from the associated index. This method combined with `synchronise()` can be useful in case of integration tests for example when each test case needs a cleaned up index in Elasticsearch.
 
 ```javascript
 GarbageModel.esTruncate(function(err){...});

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -178,7 +178,8 @@ function Mongoosastic(schema, pluginOpts) {
     filter = options && options.filter,
     transform = options && options.transform,
     customProperties = options && options.customProperties,
-    indexAutomatically = !(options && options.indexAutomatically === false);
+    indexAutomatically = !(options && options.indexAutomatically === false),
+    saveOnSynchronize = !(options && options.saveOnSynchronize === false);
 
   if (options.esClient) {
     esClient = options.esClient;
@@ -194,6 +195,29 @@ function Mongoosastic(schema, pluginOpts) {
 
     if (!typeName) {
       typeName = modelName;
+    }
+  }
+
+  function postSave(doc) {
+    function onIndex(err, res) {
+      if (!filter || !filter(doc)) {
+        doc.emit('es-indexed', err, res);
+      } else {
+        doc.emit('es-filtered', err, res);
+      }
+    }
+
+    if (doc) {
+      if (populate && populate.length) {
+        populate.forEach(populateOpts => {
+          doc.populate(populateOpts);
+        });
+        doc.execPopulate().then(popDoc => {
+          popDoc.index(onIndex);
+        });
+      } else {
+        doc.index(onIndex);
+      }
     }
   }
 
@@ -402,15 +426,18 @@ function Mongoosastic(schema, pluginOpts) {
    *
    * @param query - query for documents you want to synchronize
    */
-  schema.statics.synchronize = function synchronize(inQuery) {
+  schema.statics.synchronize = function synchronize(inQuery, inOpts) {
     var em = new events.EventEmitter(),
       closeValues = [],
       counter = 0,
       stream,
       query = inQuery || {},
+      _saveOnSynchronize,
       close = function close() {
         em.emit.apply(em, ['close'].concat(closeValues));
       };
+
+    _saveOnSynchronize = inOpts && inOpts.saveOnSynchronize !== undefined ? inOpts.saveOnSynchronize : saveOnSynchronize;
 
     // Set indexing to be bulk when synchronizing to make synchronizing faster
     // Set default values when not present
@@ -440,12 +467,18 @@ function Mongoosastic(schema, pluginOpts) {
       doc.on('es-indexed', onIndex);
       doc.on('es-filtered', onIndex);
 
-      doc.save(err => {
-        if (err) {
-          em.emit('error', err);
-          return stream.resume();
-        }
-      });
+      if (_saveOnSynchronize) {
+        // Save document with Mongoose first
+        doc.save(err => {
+          if (err) {
+            em.emit('error', err);
+            return stream.resume();
+          }
+        });
+      } else {
+        postSave(doc);
+      }
+
     });
 
     stream.on('close', (pA, pB) => {
@@ -602,29 +635,6 @@ function Mongoosastic(schema, pluginOpts) {
       bulkDelete(opts, nop);
     } else {
       deleteByMongoId(opts, nop);
-    }
-  }
-
-  function postSave(doc) {
-    function onIndex(err, res) {
-      if (!filter || !filter(doc)) {
-        doc.emit('es-indexed', err, res);
-      } else {
-        doc.emit('es-filtered', err, res);
-      }
-    }
-
-    if (doc) {
-      if (populate && populate.length) {
-        populate.forEach(populateOpts => {
-          doc.populate(populateOpts);
-        });
-        doc.execPopulate().then(popDoc => {
-          popDoc.index(onIndex);
-        });
-      } else {
-        doc.index(onIndex);
-      }
     }
   }
 


### PR DESCRIPTION
Previously a doc.save() was triggered for synchronizing doc instance to ElasticSearch.

It means that before indexing doc instance to ElasticSearch, mongoose will process all pre-save hooks of the doc model.

It is undesirable since:

depending on the situation, some pre-save's can be costly
some pre-save methods can fail, thus the document is not indexed
PR replaces doc.save(cb) by postSave(doc) when the option is provided and false.

It is the continuation of the PR #153 


