### PR TITLE
Don't always include objects when explicitly indexing fields.

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -28,6 +28,41 @@ function getTypeFromPaths(paths, field) {
 }
 
 //
+// Detect if any fields of an object are explicitly indexed.
+//
+// Can be called recursively.
+//
+// @param cleanTree
+// @return boolean
+//
+function hasExplicitIndex(cleanTree) {
+  var field, value, hasEsIndex;
+
+  for (field in cleanTree) {
+    if (!cleanTree.hasOwnProperty(field)) {
+      continue;
+    }
+
+    value = cleanTree[field];
+
+    if (value.es_indexed) {
+      hasEsIndex = true;
+    }
+
+    // If there is no type, then it's an object with subfields.
+    if (typeof value === 'object' && !value.type) {
+      hasEsIndex = hasExplicitIndex(value);
+    }
+
+    if (hasEsIndex) {
+      break;
+    }
+  }
+
+  return hasEsIndex;
+}
+
+//
 // Generates the mapping
 //
 // Can be called recursively.
@@ -62,6 +97,13 @@ function getMapping(cleanTree, inPrefix) {
     if (typeof value === 'object' && !value.type) {
       mapping[field].type = 'object';
       mapping[field].properties = getMapping(value, prefix + field);
+
+      // Check if object or it's subfields are explicitly indexed. If not, keep track implicitly.
+      if (value.es_indexed || hasExplicitIndex(value)) {
+        hasEsIndex = true;
+      } else {
+        implicitFields.push(field);
+      }
     }
 
     // If it is a objectid make it a string.

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -147,6 +147,27 @@ describe('MappingGenerator', function() {
       });
     });
 
+    it('recognizes an object and handles lack of explicit es_indexed', function(done) {
+      generator.generateMapping(new Schema({
+        name: {
+          type: String,
+          es_indexed: true
+        },
+        auth: {
+          passwordHash: {
+            type: String
+          },
+          oauthToken: {
+            type: String
+          }
+        }
+      }), function(err, mapping) {
+        mapping.properties.name.type.should.eql('string');
+        mapping.properties.should.not.have.property('auth');
+        done();
+      });
+    });
+
     it('recognizes a nested schema and handles explict es_indexed', function(done) {
 
       var ContactSchema = new Schema({


### PR DESCRIPTION
Fixes #145

If the schema being mapped includes explicit `es_index` tags, we should not include a sub-object unless one of it's fields (or, recursively, a sub-object), also has an explicit `es_index` tag.
