### PR TITLE
Reset bulk to original options.bulk instead of false. Fixes #161

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -470,10 +470,11 @@ function Mongoosastic(schema, pluginOpts) {
 
     // Set indexing to be bulk when synchronizing to make synchronizing faster
     // Set default values when not present
-    bulk = bulk || {};
-    bulk.delay = bulk.delay || 1000;
-    bulk.size = bulk.size || 1000;
-    bulk.batch = bulk.batch || 50;
+    bulk = {
+      delay: bulk && bulk.delay || 1000,
+      size: bulk && bulk.size || 1000,
+      batch: bulk && bulk.batch || 50,
+    };
 
     setIndexNameIfUnset(this.modelName);
 
@@ -517,7 +518,7 @@ function Mongoosastic(schema, pluginOpts) {
         if (counter === 0 && bulkBuffer.length === 0) {
           clearInterval(closeInterval);
           close();
-          bulk = false;
+          bulk = options && options.bulk;
         }
       }, 1000);
     });


### PR DESCRIPTION
This is intended to resolve #161 by resetting bulk to the (unmodified) original value from options instead of resetting to false.
