### PR TITLE
Eliminate Mongoose Query.prototype.stream() deprecation warning

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Jon Burgess <jonjburgess@gmail.com>
 Jose Maza <jose.maza@rulesware.com>
 Kyle Mathews <mathews.kyle@gmail.com>
 Marcos Sanz <marcos.sanz@13genius.com>
+Matt Audesse <matt@mattaudesse.com>
 Nadeesha Cabral <nadeesha.cabral@gmail.com>
 Nicolas McCurdy <thenickperson@gmail.com>
 Nico Schlömer <nico.schloemer@gmail.com>

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -477,7 +477,7 @@ function Mongoosastic(schema, pluginOpts) {
 
     setIndexNameIfUnset(this.modelName);
 
-    stream = this.find(query).batchSize(bulk.batch).stream();
+    stream = this.find(query).batchSize(bulk.batch).cursor();
 
     stream.on('data', doc => {
       stream.pause();


### PR DESCRIPTION
Hey there,

This is a very easy fix for issue #230 . I don't imagine it warrants any new test cases, and ```npm test``` passes just fine.

**NB** I know the CONTRIBUTING guide specifies that all PRs must fork from/merge back to ```develop``` but that branch doesn't exist, so I've gone straight to ```master``` instead.

Thanks!