### PR TITLE
Exclude aggs from being added to the esQuery

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -618,7 +618,7 @@ function Mongoosastic (schema, pluginOpts) {
     }
 
     Object.keys(opts).forEach(opt => {
-      if (!opt.match(/(hydrate|sort)/) && opts.hasOwnProperty(opt)) {
+      if (!opt.match(/(hydrate|sort|aggs)/) && opts.hasOwnProperty(opt)) {
         esQuery[opt] = opts[opt]
       }
 


### PR DESCRIPTION
aggs are already added to the body, not needed in `esQuery`. Fixes errors with Elasticsearch v5.0.0 (complaining about unknown field `aggs`).