### PR TITLE
Fix (#5) mapping creation of nested references

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -228,9 +228,26 @@ function getCleanTree (tree, paths, inPrefix) {
 // @return cleanTree modified
 //
 function nestedSchema (paths, field, cleanTree, value, prefix) {
+  let treeNode
+  let subTree
   // A nested array can contain complex objects
   if (paths[prefix + field] && paths[prefix + field].schema && paths[prefix + field].schema.tree && paths[prefix + field].schema.paths) {
     cleanTree[field] = getCleanTree(paths[prefix + field].schema.tree, paths[prefix + field].schema.paths, '')
+  } else if (paths[prefix + field] && Array.isArray(paths[prefix + field].options.type) && paths[prefix + field].options.type[0].es_schema &&
+    paths[prefix + field].options.type[0].es_schema.tree && paths[prefix + field].options.type[0].es_schema.paths) {
+    // A nested array of references filtered by the 'es_select' option
+    subTree = paths[field].options.type[0].es_schema.tree
+    if (paths[field].options.type[0].es_select) {
+      for (treeNode in subTree) {
+        if (!subTree.hasOwnProperty(treeNode)) {
+          continue
+        }
+        if (paths[field].options.type[0].es_select.split(' ').indexOf(treeNode) === -1) {
+          delete subTree[treeNode]
+        }
+      }
+    }
+    cleanTree[field] = getCleanTree(subTree, paths[prefix + field].options.type[0].es_schema.paths, '')
   } else if (paths[prefix + field] && paths[prefix + field].caster && paths[prefix + field].caster.instance) {
     // Even for simple types the value can be an object if there is other attributes than type
     if (typeof value[0] === 'object') {

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -228,26 +228,9 @@ function getCleanTree (tree, paths, inPrefix) {
 // @return cleanTree modified
 //
 function nestedSchema (paths, field, cleanTree, value, prefix) {
-  let treeNode;
-  let subTree;
   // A nested array can contain complex objects
   if (paths[prefix + field] && paths[prefix + field].schema && paths[prefix + field].schema.tree && paths[prefix + field].schema.paths) {
     cleanTree[field] = getCleanTree(paths[prefix + field].schema.tree, paths[prefix + field].schema.paths, '')
-  } 
-  // A nested array of references filtered by the 'es_select' option
-  else if (paths[prefix + field] && Array.isArray(paths[prefix + field].options.type) && paths[prefix + field].options.type[0].es_schema && paths[prefix + field].options.type[0].es_schema.tree && paths[prefix + field].options.type[0].es_schema.paths) {
-    subTree = paths[field].options.type[0].es_schema.tree;
-    if (paths[field].options.es_select) {
-      for (treeNode in subTree) {
-        if (!subTree.hasOwnProperty(treeNode)) {
-          continue
-        }
-        if (paths[field].options.es_select.split(' ').indexOf(treeNode) === -1) {
-          delete subTree[treeNode]
-        }
-      }
-    }
-    cleanTree[field] = getCleanTree(subTree, paths[prefix + field].options.type[0].es_schema.paths, '')
   } else if (paths[prefix + field] && paths[prefix + field].caster && paths[prefix + field].caster.instance) {
     // Even for simple types the value can be an object if there is other attributes than type
     if (typeof value[0] === 'object') {

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -228,9 +228,26 @@ function getCleanTree (tree, paths, inPrefix) {
 // @return cleanTree modified
 //
 function nestedSchema (paths, field, cleanTree, value, prefix) {
+  let treeNode;
+  let subTree;
   // A nested array can contain complex objects
   if (paths[prefix + field] && paths[prefix + field].schema && paths[prefix + field].schema.tree && paths[prefix + field].schema.paths) {
     cleanTree[field] = getCleanTree(paths[prefix + field].schema.tree, paths[prefix + field].schema.paths, '')
+  } 
+  // A nested array of references filtered by the 'es_select' option
+  else if (paths[prefix + field] && Array.isArray(paths[prefix + field].options.type) && paths[prefix + field].options.type[0].es_schema && paths[prefix + field].options.type[0].es_schema.tree && paths[prefix + field].options.type[0].es_schema.paths) {
+    subTree = paths[field].options.type[0].es_schema.tree;
+    if (paths[field].options.es_select) {
+      for (treeNode in subTree) {
+        if (!subTree.hasOwnProperty(treeNode)) {
+          continue
+        }
+        if (paths[field].options.es_select.split(' ').indexOf(treeNode) === -1) {
+          delete subTree[treeNode]
+        }
+      }
+    }
+    cleanTree[field] = getCleanTree(subTree, paths[prefix + field].options.type[0].es_schema.paths, '')
   } else if (paths[prefix + field] && paths[prefix + field].caster && paths[prefix + field].caster.instance) {
     // Even for simple types the value can be an object if there is other attributes than type
     if (typeof value[0] === 'object') {

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -467,5 +467,68 @@ describe('MappingGenerator', function() {
         done();
       });
     });
+
+    it('maps all fields from array of referenced schema', function(done) {
+      var Name = new Schema({
+        firstName: String,
+        lastName: String
+      });
+      generator.generateMapping(new Schema({
+        name: {
+          type: [{type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name}],
+          es_type: 'object'
+        }
+      }), function(err, mapping) {
+        mapping.properties.name.properties.firstName.type.should.eql('string');
+        mapping.properties.name.properties.lastName.type.should.eql('string');
+        done();
+      });
+    });
+
+    it('maps only selected fields from array of referenced schema', function(done) {
+      var Name = new Schema({
+        firstName: String,
+        lastName: String
+      });
+      generator.generateMapping(new Schema({
+        name: {
+          type: [{type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName'}],
+          es_type: 'object'
+        }
+      }), function(err, mapping) {
+        mapping.properties.name.properties.firstName.type.should.eql('string');
+        should.not.exist(mapping.properties.name.properties.lastName);
+        done();
+      });
+    });
+
+    it('maps a geo_point field of an nested referenced schema as a geo_point', function(done) {
+      var Location = new Schema({
+        name: String,
+        coordinates: {
+          type: {
+            geo_point: {
+              type: String,
+              es_type: 'geo_point',
+              es_lat_lon: true
+            },
+
+            lat: {type: Number, default: 0},
+            lon: {type: Number, default: 0}
+          },
+          es_type: 'geo_point'
+        }
+      });
+
+      generator.generateMapping(new Schema({
+        locations: {
+          type: [{type: Schema.Types.ObjectId, ref: 'Location', es_schema: Location}],
+          es_type: 'object'
+        }
+      }), function(err, mapping) {
+        mapping.properties.locations.properties.coordinates.type.should.eql('geo_point');
+        done();
+      })
+    })
   });
 });

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -528,7 +528,7 @@ describe('MappingGenerator', function() {
       }), function(err, mapping) {
         mapping.properties.locations.properties.coordinates.type.should.eql('geo_point');
         done();
-      })
-    })
+      });
+    });
   });
 });


### PR DESCRIPTION
Use the es_schema provided in the reference instead of the caster to create the mapping in the nestedSchema method during the mapping generation. The mapping is then more accurate. Prevent geo_points to be transformed to a couple of double  "lat/lon" when they are in an referenced object.