### PR TITLE
don't remove _id field in nested objects mapping

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -119,7 +119,7 @@ function getMapping (cleanTree, inPrefix) {
 // @param prefix
 // @return the tree
 //
-function getCleanTree (tree, paths, inPrefix) {
+function getCleanTree (tree, paths, inPrefix, isRoot) {
   let cleanTree = {}
   let type = ''
   let value = {}
@@ -135,7 +135,7 @@ function getCleanTree (tree, paths, inPrefix) {
   paths = cloneDeep(paths)
 
   for (field in tree) {
-    if (prefix === '' && field === '_id') {
+    if (prefix === '' && field === '_id' && isRoot) {
       continue
     }
 
@@ -273,7 +273,7 @@ function nestedSchema (paths, field, cleanTree, value, prefix) {
 function Generator () {}
 
 Generator.prototype.generateMapping = function generateMapping (schema, cb) {
-  const cleanTree = getCleanTree(schema.tree, schema.paths, '')
+  const cleanTree = getCleanTree(schema.tree, schema.paths, '', true)
   delete cleanTree[schema.get('versionKey')]
   let mapping = getMapping(cleanTree, '')
   cb(null, {


### PR DESCRIPTION
If Schema in mongoose is something like this :
```
{
  "name": {
    "type": String,
    "required": true,
    "unique": true
  },
  "category": [{
    "type": String,
    "required": true
  }],
  "mrp": Number,
  "sellers": [{
    "name": { type: String },
    "_id": {type: mongoose.Schema.Types.ObjectId},
  }],
}, {
    "timestamps": true
  })
```
The mapping generated by mongoosastic ignores '_id' in the seller object
