### PR TITLE
Decrement counter for failed documents

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -530,6 +530,7 @@ function Mongoosastic (schema, pluginOpts) {
         // Save document with Mongoose first
         doc.save(err => {
           if (err) {
+            counter--
             em.emit('error', err)
             return stream.resume()
           }


### PR DESCRIPTION
This addresses issue #353. Ideally it makes more sense to call the `data` callback with a document-specific error such as a schema validation error. However that could be a potentially breaking change.

This fix decrements the stream counter so that the application using `synchronize` can still get the `close` event even though there are document save specific errors (since the `stream` is clearly resumed in this scenario)

