### PR TITLE
Fix hits sometimes having a value of undefined

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -143,6 +143,8 @@ function hydrate (res, model, options, cb) {
       })
       hits = results.hits.map(result => docsMap[result._id])
     }
+    
+    hits = hits.filter(f => f !== undefined)
 
     if (options.highlight || options.hydrateWithESResults) {
       hits.forEach(doc => {


### PR DESCRIPTION
Sometimes the array of hits contains a value of undefined, which causes mongoosastic to crash when building up the doc, since `_id` won't be present, as per this error:

```
TypeError: Cannot read property '_id' of undefined
at hits.forEach.doc (/Users/alexdovzhanyn/projects/ursa/node_modules/mongoosastic/lib/mongoosastic.js:151:36)
```

A quick and easy fix is to filter out those undefined hits before looping over them.

Note: I was originally going to make this PR to the develop branch, as per the contributing guidelines, but there seems to be no develop branch.