### PR TITLE
elastic 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,16 @@ language: node_js
 
 node_js:
   - 8
+  - 10
   - stable
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
   - sudo apt-get -y install docker-ce
-  - docker pull docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+  - docker pull docker.elastic.co/elasticsearch/elasticsearch:7.3.1
   - docker ps -a
-  - docker run -p 9200:9200 -p 9300:9300 -d -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+  - docker run -p 9200:9200 -p 9300:9300 -d -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.3.1
   - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
 
 services:

--- a/package-lock.json
+++ b/package-lock.json
@@ -679,9 +679,9 @@
       }
     },
     "elasticsearch": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-16.1.1.tgz",
-      "integrity": "sha512-OF2fIjcTPfq/4Tj6k4/SZr2IIlfWlBBQoy/em225mfevYFW1abN3nyXKWldXGV+eWI6LWNqB8lb3hAP4d6Rh/Q==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-16.3.0.tgz",
+      "integrity": "sha512-Xy4vma+YJD2I3vudoV5RIgcMFnc/69SVef/BGOtmicvgUdzYs5mLY66FIANb5KnVS60i+zsnhvf/bYJYJklBsg==",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "lib/mongoosastic.js",
   "dependencies": {
-    "elasticsearch": "16.1.1",
+    "elasticsearch": "16.3.0",
     "lodash.clonedeep": "4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
First we need to add support for Elastic v7+ and then migrate to the new official client.

Check [this guide on Elastic.co](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/breaking-changes.html) 