### PR TITLE
fix bug causes error with hydrate

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -108,7 +108,7 @@ function createMappingIfNotPresent (options, cb) {
 }
 
 function hydrate (res, model, options, cb) {
-  const results = res.hits
+  const results = res.body.hits
   const resultsMap = {}
   const ids = results.hits.map((result, idx) => {
     resultsMap[result._id] = idx


### PR DESCRIPTION
This fixes error "Cannot read property 'hits' of undefined" when Model.search({...}, { hydrate: true }).