### PR TITLE
Change automatic indexing of subdocuments

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -163,10 +163,10 @@ function getCleanTree (tree, paths, inPrefix, isRoot) {
     // Field has some kind of type
     if (type) {
       // If it is an nested schema
-      if (value[0] || type === 'embedded') {
+      if ((value[0] && value[0].es_indexed === true) || type === 'embedded') {
         // A nested array can contain complex objects
         nestedSchema(paths, field, cleanTree, value, prefix) // eslint-disable-line no-use-before-define
-      } else if (value.type && Array.isArray(value.type)) {
+      } else if (value.es_indexed === true && value.type && Array.isArray(value.type)) {
         // An object with a nested array
         nestedSchema(paths, field, cleanTree, value, prefix) // eslint-disable-line no-use-before-define
         // Merge top level es settings

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -388,7 +388,8 @@ describe('MappingGenerator', function () {
       const schema = new Schema({
         string: String,
         mixed_field: {
-          type: mongoose.Schema.Types.Mixed
+          type: mongoose.Schema.Types.Mixed,
+          es_indexed: true
         },
         mixed_arr_field: {
           type: [mongoose.Schema.Types.Mixed],

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -395,9 +395,12 @@ describe('MappingGenerator', function () {
           es_indexed: true
         },
         obj_mixed: {
-          mixed: {
-            type: mongoose.Schema.Types.Mixed
-          }
+          type: new Schema({
+            mixed: {
+              type: mongoose.Schema.Types.Mixed
+            }
+          }),
+          es_indexed: true
         }
       })
       const mongoosastic = require('../lib/mongoosastic')

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -258,7 +258,7 @@ describe('MappingGenerator', function () {
         }
       })
 
-      const schema = new Schema({ name: [NameSchema] })
+      const schema = new Schema({ name: { type: [NameSchema], es_indexed: true } })
       const mapping = generator.generateMapping(schema)
 
       mapping.properties.name.type.should.eql('object')
@@ -303,7 +303,7 @@ describe('MappingGenerator', function () {
 
     it('recognizes a nested array with a simple type and maps it as a simple attribute', function (done) {
       const schema = new Schema({
-        contacts: [String]
+        contacts: { type: [String], es_indexed: true }
       })
 
       const mapping = generator.generateMapping(schema)
@@ -316,7 +316,8 @@ describe('MappingGenerator', function () {
       const schema = new Schema({
         contacts: [{
           type: String,
-          es_index: 'not_analyzed'
+          es_index: 'not_analyzed',
+          es_indexed: true
         }]
       })
 
@@ -331,6 +332,7 @@ describe('MappingGenerator', function () {
       const schema = new Schema({
         name: String,
         contacts: [{
+          es_indexed: true,
           email: {
             type: String,
             es_index: 'not_analyzed'
@@ -366,7 +368,7 @@ describe('MappingGenerator', function () {
       })
 
       const schema = new Schema({
-        name: [PersonSchema]
+        name: { type: [PersonSchema], es_indexed: true }
       })
 
       const mapping = generator.generateMapping(schema)
@@ -577,7 +579,7 @@ describe('MappingGenerator', function () {
 
       const schema = new Schema({
         name: {
-          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name }],
+          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_indexed: true }],
           es_type: 'object'
         }
       })
@@ -597,7 +599,7 @@ describe('MappingGenerator', function () {
 
       const schema = new Schema({
         name: {
-          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName' }],
+          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName', es_indexed: true }],
           es_type: 'object'
         }
       })
@@ -629,7 +631,7 @@ describe('MappingGenerator', function () {
 
       const schema = new Schema({
         locations: {
-          type: [{ type: Schema.Types.ObjectId, ref: 'Location', es_schema: Location }],
+          type: [{ type: Schema.Types.ObjectId, ref: 'Location', es_schema: Location, es_indexed: true }],
           es_type: 'object'
         }
       })

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -331,14 +331,16 @@ describe('MappingGenerator', function () {
     it('recognizes a nested array with a complex object and maps it', function (done) {
       const schema = new Schema({
         name: String,
-        contacts: [{
+        contacts: {
           es_indexed: true,
-          email: {
-            type: String,
-            es_index: 'not_analyzed'
-          },
-          telephone: String
-        }]
+          type: [{
+            email: {
+              type: String,
+              es_index: 'not_analyzed'
+            },
+            telephone: String
+          }]
+        }
       })
 
       const mapping = generator.generateMapping(schema)
@@ -579,8 +581,9 @@ describe('MappingGenerator', function () {
 
       const schema = new Schema({
         name: {
-          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_indexed: true }],
-          es_type: 'object'
+          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name }],
+          es_type: 'object',
+          es_indexed: true
         }
       })
 
@@ -599,8 +602,9 @@ describe('MappingGenerator', function () {
 
       const schema = new Schema({
         name: {
-          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName', es_indexed: true }],
-          es_type: 'object'
+          type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName' }],
+          es_type: 'object',
+          es_indexed: true
         }
       })
 
@@ -631,8 +635,9 @@ describe('MappingGenerator', function () {
 
       const schema = new Schema({
         locations: {
-          type: [{ type: Schema.Types.ObjectId, ref: 'Location', es_schema: Location, es_indexed: true }],
-          es_type: 'object'
+          type: [{ type: Schema.Types.ObjectId, ref: 'Location', es_schema: Location }],
+          es_type: 'object',
+          es_indexed: true
         }
       })
 

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -331,16 +331,16 @@ describe('MappingGenerator', function () {
     it('recognizes a nested array with a complex object and maps it', function (done) {
       const schema = new Schema({
         name: String,
-        contacts: {
+        contacts: [{
           es_indexed: true,
-          type: [{
+          type: new Schema({
             email: {
               type: String,
               es_index: 'not_analyzed'
             },
             telephone: String
-          }]
-        }
+          })
+        }]
       })
 
       const mapping = generator.generateMapping(schema)
@@ -391,7 +391,8 @@ describe('MappingGenerator', function () {
           type: mongoose.Schema.Types.Mixed
         },
         mixed_arr_field: {
-          type: [mongoose.Schema.Types.Mixed]
+          type: [mongoose.Schema.Types.Mixed],
+          es_indexed: true
         },
         obj_mixed: {
           mixed: {


### PR DESCRIPTION
Quick fix to don't automatically index subdocuments. Must provide es_indexed: true at the top level to index.

Before these subdocuments would have been indexed by default with all their fields :

`children: [childSchema]`

```javascript
children: [{
  type: childSchema,
}]
```

```javascript
children: {
  type: [childSchema],
}
```

Now, must precise `es_indexed: true` to be indexed as : 

```javascript
children: [{
  es_indexed: true,
  type: childSchema,
}]
```

```javascript
children: {
  es_indexed: true,
  type: [childSchema],
}
```

Answer of issue #534.