### PR TITLE
Fix createMapping if index does not exist

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -80,7 +80,7 @@ function createMappingIfNotPresent (options, cb) {
       return cb(err)
     }
 
-    if (exists) {
+    if (exists.body) {
       return client.indices.putMapping({
         index: indexName,
         body: inputMapping


### PR DESCRIPTION
Elasticsearch's indices.exists method returns APIResponse with `body` set to boolean result.