### PR TITLE
patched bug for elastic cloud

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -107,7 +107,7 @@ function createMappingIfNotPresent (options, cb) {
 }
 
 function hydrate (res, model, options, cb) {
-  const results = res.hits
+  const results = res.hits || res.body.hits;
   const resultsMap = {}
   const ids = results.hits.map((result, idx) => {
     resultsMap[result._id] = idx
@@ -480,7 +480,7 @@ function Mongoosastic (schema, pluginOpts) {
       if (err) {
         return cb(err)
       }
-      res = reformatESTotalNumber(res)
+      res = (res.hits) ? reformatESTotalNumber(res) :reformatESTotalNumber(res.body)
       if (res.hits.total) {
         res.hits.hits.forEach(doc => {
           opts.model = doc
@@ -670,7 +670,7 @@ function Mongoosastic (schema, pluginOpts) {
         return cb(err)
       }
 
-      const resp = reformatESTotalNumber(res)
+      const resp = (res.hits) ? reformatESTotalNumber(res) :reformatESTotalNumber(res.body)
       if (alwaysHydrate || opts.hydrate) {
         hydrate(resp, _this, opts, cb)
       } else {
@@ -679,7 +679,8 @@ function Mongoosastic (schema, pluginOpts) {
     })
   }
 
-  function reformatESTotalNumber (res) {
+  function reformatESTotalNumber(res) {
+  
     Object.assign(res.hits, {
       total: res.hits.total.value,
       extTotal: res.hits.total


### PR DESCRIPTION
The elastic cloud returns result of search query in body of response. The hits are available in res.body.hits instead of res.hits, this was causing error in following functions -:

- hydrate
- reformatESTotalNumber

as they were trying to access the undefined property of object.