### PR TITLE
Update dependencies

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,5 @@
 module.exports = {
+  testTimeout: 10000,
   clearMocks: true,
   roots: [
     '<rootDir>/test'

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,6 +1,6 @@
 import { MongoosasticDocument } from './types'
 
-export function postSave(doc: MongoosasticDocument): void {
+export async function postSave(doc: MongoosasticDocument): Promise<void> {
   if (!doc) {
     return
   }
@@ -20,15 +20,11 @@ export function postSave(doc: MongoosasticDocument): void {
   const populate = options && options.populate
   if (doc) {
     if (populate && populate.length) {
-      populate.forEach((populateOpts) => {
-        doc.populate(populateOpts)
-      })
-      doc.execPopulate().then((popDoc) => {
-        popDoc
-          .index()
-          .then((res) => onIndex(null, res))
-          .catch((err) => onIndex(err, null))
-      })
+      const popDoc = await doc.populate(populate)
+      popDoc
+        .index()
+        .then((res) => onIndex(null, res))
+        .catch((err) => onIndex(err, null))
     } else {
       doc
         .index()

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,12 +1,12 @@
 import { ApiResponse } from '@elastic/elasticsearch'
 import { Search } from '@elastic/elasticsearch/api/requestParams'
-import { QueryContainer, SearchRequest, SearchResponse } from '@elastic/elasticsearch/api/types'
+import { QueryDslQueryContainer, SearchRequest, SearchResponse } from '@elastic/elasticsearch/api/types'
 import { EsSearchOptions, HydratedSearchResults, MongoosasticDocument, MongoosasticModel } from './types'
 import { getIndexName, hydrate, isString, isStringArray, reformatESTotalNumber } from './utils'
 
 export async function search(
   this: MongoosasticModel<MongoosasticDocument>,
-  query: QueryContainer,
+  query: QueryDslQueryContainer,
   opts: EsSearchOptions = {}
 ): Promise<ApiResponse<SearchResponse, unknown> | ApiResponse<HydratedSearchResults>> {
   const fullQuery = {

--- a/lib/statics.ts
+++ b/lib/statics.ts
@@ -1,5 +1,5 @@
 import { Search } from '@elastic/elasticsearch/api/requestParams'
-import { Property, PropertyName, QueryContainer, SearchResponse } from '@elastic/elasticsearch/api/types'
+import { MappingProperty, PropertyName, QueryDslQueryContainer, SearchResponse } from '@elastic/elasticsearch/api/types'
 import { ApiResponse, RequestBody } from '@elastic/elasticsearch/lib/Transport'
 import { EventEmitter } from 'events'
 import { FilterQuery } from 'mongoose'
@@ -12,7 +12,7 @@ import { filterMappingFromMixed, getIndexName, reformatESTotalNumber } from './u
 export async function createMapping(
   this: MongoosasticModel<MongoosasticDocument>,
   body: RequestBody
-): Promise<Record<PropertyName, Property>> {
+): Promise<Record<PropertyName, MappingProperty>> {
   const options = this.esOptions()
   const client = this.esClient()
 
@@ -184,7 +184,7 @@ export async function refresh(this: MongoosasticModel<MongoosasticDocument>): Pr
 
 export async function esCount(
   this: MongoosasticModel<MongoosasticDocument>,
-  query: QueryContainer
+  query: QueryDslQueryContainer
 ): Promise<ApiResponse> {
   if (query === undefined) {
     query = {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -3,16 +3,16 @@
 import { ApiResponse, Client, ClientOptions } from '@elastic/elasticsearch'
 import {
   CountResponse,
-  Highlight,
-  Hit,
-  HitsMetadata,
-  Property,
+  IndicesRefreshResponse,
+  MappingProperty,
+  MappingTypeMapping,
   PropertyName,
-  QueryContainer,
-  RefreshResponse,
+  QueryDslQueryContainer,
+  SearchHighlight,
+  SearchHit,
+  SearchHitsMetadata,
   SearchRequest,
   SearchResponse,
-  TypeMapping,
 } from '@elastic/elasticsearch/api/types'
 import { RequestBody } from '@elastic/elasticsearch/lib/Transport'
 import { EventEmitter } from 'events'
@@ -30,7 +30,7 @@ declare interface RoutingFn {
   (doc: Document): any;
 }
 
-declare interface GeneratedMapping extends TypeMapping {
+declare interface GeneratedMapping extends MappingTypeMapping {
   cast?(doc: any): any;
 }
 
@@ -38,7 +38,7 @@ declare interface HydratedSearchResults<TDocument = unknown> extends SearchRespo
   hits: HydratedSearchHits<TDocument>;
 }
 
-declare interface HydratedSearchHits<TDocument> extends HitsMetadata<TDocument> {
+declare interface HydratedSearchHits<TDocument> extends SearchHitsMetadata<TDocument> {
   hydrated: Array<TDocument>;
 }
 
@@ -117,7 +117,7 @@ declare type Options = {
 
 declare type EsSearchOptions = {
   aggs?: any;
-  highlight?: Highlight;
+  highlight?: SearchHighlight;
   hydrate?: boolean;
   hydrateOptions?: QueryOptions;
   hydrateWithESResults?: any;
@@ -130,7 +130,7 @@ declare type EsSearchOptions = {
 
 declare interface MongoosasticDocument<TDocument = any> extends Document<TDocument>, EventEmitter {
   _highlight?: Record<string, string[]> | undefined;
-  _esResult?: Hit<TDocument>;
+  _esResult?: SearchHit<TDocument>;
 
   esClient(): Client;
 
@@ -144,11 +144,11 @@ declare interface MongoosasticDocument<TDocument = any> extends Document<TDocume
 interface MongoosasticModel<T> extends Model<T> {
   bulkError(): EventEmitter;
 
-  createMapping(body?: RequestBody): Promise<Record<PropertyName, Property>>;
+  createMapping(body?: RequestBody): Promise<Record<PropertyName, MappingProperty>>;
 
   esClient(): Client;
 
-  esCount(query?: QueryContainer): Promise<ApiResponse<CountResponse>>;
+  esCount(query?: QueryDslQueryContainer): Promise<ApiResponse<CountResponse>>;
 
   esOptions(): Options;
 
@@ -162,9 +162,9 @@ interface MongoosasticModel<T> extends Model<T> {
 
   getMapping(): Record<string, any>;
 
-  refresh(): Promise<ApiResponse<RefreshResponse>>;
+  refresh(): Promise<ApiResponse<IndicesRefreshResponse>>;
 
-  search(query: QueryContainer, options?: EsSearchOptions): Promise<ApiResponse<HydratedSearchResults<T>>>;
+  search(query: QueryDslQueryContainer, options?: EsSearchOptions): Promise<ApiResponse<HydratedSearchResults<T>>>;
 
   synchronize(query?: any, options?: SynchronizeOptions): EventEmitter;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
 import { ApiResponse } from '@elastic/elasticsearch'
-import { Property, PropertyName, SearchResponse, TotalHits } from '@elastic/elasticsearch/api/types'
+import { MappingProperty, PropertyName, SearchResponse, SearchTotalHits } from '@elastic/elasticsearch/api/types'
 import { isEmpty } from 'lodash'
 import {
   DeleteByIdOptions,
@@ -28,8 +28,8 @@ export function getIndexName(doc: MongoosasticDocument | MongoosasticModel<Mongo
   }
 }
 
-export function filterMappingFromMixed(props: Record<PropertyName, Property>): Record<PropertyName, Property> {
-  const filteredMapping: Record<PropertyName, Property> = {}
+export function filterMappingFromMixed(props: Record<PropertyName, MappingProperty>): Record<PropertyName, MappingProperty> {
+  const filteredMapping: Record<PropertyName, MappingProperty> = {}
   Object.keys(props).map((key) => {
     const field = props[key]
     if (field.type !== 'mixed') {
@@ -103,7 +103,7 @@ export function reformatESTotalNumber<T = unknown>(
   res: ApiResponse<SearchResponse<T>>
 ): ApiResponse<SearchResponse<T>> {
   Object.assign(res.body.hits, {
-    total: (res.body.hits.total as TotalHits).value,
+    total: (res.body.hits.total as SearchTotalHits).value,
     extTotal: res.body.hits.total,
   })
   return res

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@elastic/elasticsearch": "7.13.0",
+        "@elastic/elasticsearch": "^7.15.0",
         "lodash": "^4.17.21",
         "mongoose": "^6.0.13"
       },
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
-      "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.15.0.tgz",
+      "integrity": "sha512-FUKvjV2IKtIiWsvBy7D+wLbSEONsmNR15RRN7P/Sb30g4ObZRHH2qGOP5PPnzxdntEkzZ8HzY7nKKXFS+3Du1g==",
       "dependencies": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",
@@ -8514,9 +8514,9 @@
       }
     },
     "@elastic/elasticsearch": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz",
-      "integrity": "sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.15.0.tgz",
+      "integrity": "sha512-FUKvjV2IKtIiWsvBy7D+wLbSEONsmNR15RRN7P/Sb30g4ObZRHH2qGOP5PPnzxdntEkzZ8HzY7nKKXFS+3Du1g==",
       "requires": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,18 @@
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "7.13.0",
-        "lodash": "4.17.21",
-        "mongoose": "5.13.13"
+        "lodash": "^4.17.21",
+        "mongoose": "^6.0.13"
       },
       "devDependencies": {
         "@types/jest": "27.0.2",
         "@types/lodash": "4.14.176",
         "@types/node": "16.11.7",
-        "@types/supertest": "2.0.11",
         "@typescript-eslint/eslint-plugin": "5.3.1",
         "@typescript-eslint/parser": "5.3.1",
         "coveralls": "3.1.1",
         "eslint": "8.2.0",
         "jest": "26.6.3",
-        "supertest": "6.1.6",
         "ts-jest": "26.5.6",
         "ts-node": "10.4.0",
         "typescript": "4.4.4"
@@ -42,9 +40,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -407,9 +405,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
-      "integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1133,20 +1131,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
-      "dev": true
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1202,15 +1186,6 @@
       "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==",
       "dev": true
     },
-    "node_modules/@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dependencies": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "16.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
@@ -1234,23 +1209,18 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
-    "node_modules/@types/superagent": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.13.tgz",
-      "integrity": "sha512-YIGelp3ZyMiH0/A09PMAORO0EBGlF5xIKfDpK74wdYvWUs2o96b5CItJcWPdH409b7SAXIIG6p8NdU/4U2Maww==",
-      "dev": true,
-      "dependencies": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
-      }
+    "node_modules/@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
     },
-    "node_modules/@types/supertest": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.11.tgz",
-      "integrity": "sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==",
-      "dev": true,
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
       "dependencies": {
-        "@types/superagent": "*"
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -1298,6 +1268,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
@@ -1406,6 +1391,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -1857,6 +1857,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1865,20 +1884,6 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1909,9 +1914,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.0.tgz",
-      "integrity": "sha512-ER2M0g5iAR84fS/zjBDqEgU6iO5fS9JI2EkHr5zxDxYEFk3LjhU9Vpp/INb6RMQphxko7PDV1FH38H/qVP5yCA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+      "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
       "dev": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001280",
@@ -1953,11 +1958,37 @@
       }
     },
     "node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.4.tgz",
+      "integrity": "sha512-wIt0bPACnx8Ju9r6IsS2wVtGDHBr9Dxb+U29A1YED2pu8XOhS8aKjOnLZ8sxyXkPwanoK7iWWVhS1+coxde6xA==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -1986,19 +2017,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2018,9 +2036,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001280",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-      "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
+      "version": "1.0.30001282",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
+      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2271,12 +2289,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
-      "dev": true
-    },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -2287,9 +2299,10 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/coveralls": {
       "version": "3.1.1",
@@ -2463,9 +2476,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
       "engines": {
         "node": ">=0.10"
       }
@@ -2553,9 +2566,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.896",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.896.tgz",
-      "integrity": "sha512-NcGkBVXePiuUrPLV8IxP43n1EOtdg+dudVjrfVEUd/bOqpQUFZ2diL5PPYzbgEhZFEltdXV3AcyKwGnEQ5lhMA==",
+      "version": "1.3.901",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.901.tgz",
+      "integrity": "sha512-ToJdV2vzwT2jeAsw8zIggTFllJ4Kxvwghk39AhJEHHlIxor10wsFI3wo69p8nFc0s/ATWBqugPv/k3nW4Y9Mww==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3267,12 +3280,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
-    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -3379,16 +3386,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-      "dev": true,
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -3449,20 +3446,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -3631,18 +3614,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3798,6 +3769,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
@@ -3861,7 +3851,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
@@ -4074,7 +4065,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5224,15 +5216,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -5244,18 +5227,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -5332,113 +5303,88 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.4.tgz",
+      "integrity": "sha512-Cv/sk8on/tpvvqbEvR1h03mdyNdyvvO+WhtFlL4jrZ+DSsN/oSQHVqmJQI/sBCqqbOArFcYCAYDfyzqFwV4GSQ==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^4.5.4",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12.9.0"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws4": {
-          "optional": true
-        },
-        "bson-ext": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
+        "saslprep": "^1.0.3"
       }
     },
-    "node_modules/mongodb/node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
+      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
       "dependencies": {
-        "require-at": "^1.0.6"
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mongoose": {
-      "version": "5.13.13",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.13.tgz",
-      "integrity": "sha512-M55tpCr/p5i6vdJ54nm4MG6/7SKV4JqlWnqbx6yCRuAuW05CZ7u+gNuHVPQVF9dZ59ALXjOtPEUl+OXklAa7ng==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.0.13.tgz",
+      "integrity": "sha512-/M/YKgx23fCX+j0lwObaHbCibXnMjyWeQrXZf0WaQeS/hL86wQVSmaOxh+kZXfyLOUr+vT2Hl44o50GZHUrKWw==",
       "dependencies": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
+        "bson": "^4.2.2",
         "kareem": "2.3.2",
-        "mongodb": "3.7.3",
-        "mongoose-legacy-pluralize": "1.0.2",
+        "mongodb": "4.1.4",
         "mpath": "0.8.4",
-        "mquery": "3.2.5",
+        "mquery": "4.0.0",
         "ms": "2.1.2",
-        "optional-require": "1.0.x",
         "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
         "sift": "13.5.2",
         "sliced": "1.0.1"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "peerDependencies": {
-        "mongoose": "*"
-      }
-    },
     "node_modules/mongoose/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/mongoose/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/mpath": {
       "version": "0.8.4",
@@ -5449,32 +5395,17 @@
       }
     },
     "node_modules/mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.0.tgz",
+      "integrity": "sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==",
       "dependencies": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
+        "debug": "4.x",
         "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
       }
-    },
-    "node_modules/mquery/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/mquery/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5693,15 +5624,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -5748,14 +5670,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/optionator": {
@@ -6037,11 +5951,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -6084,7 +5993,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6172,20 +6080,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/regex-not": {
@@ -6309,14 +6203,6 @@
       "dev": true,
       "bin": {
         "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -6453,7 +6339,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -6877,20 +6764,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/sift": {
       "version": "13.5.2",
@@ -7359,14 +7232,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -7443,70 +7308,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/superagent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
-      "dev": true,
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
-        "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">= 7.0.0"
-      }
-    },
-    "node_modules/superagent/node_modules/qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/superagent/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/supertest": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
-      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
-      "dev": true,
-      "dependencies": {
-        "methods": "^1.1.2",
-        "superagent": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -7758,21 +7559,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -7952,11 +7738,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8019,12 +7800,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -8266,9 +8041,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
       "dev": true
     },
     "@babel/core": {
@@ -8548,9 +8323,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
-      "integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw==",
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -9140,20 +8915,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -9209,15 +8970,6 @@
       "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==",
       "dev": true
     },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "16.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
@@ -9241,23 +8993,18 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
-    "@types/superagent": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.13.tgz",
-      "integrity": "sha512-YIGelp3ZyMiH0/A09PMAORO0EBGlF5xIKfDpK74wdYvWUs2o96b5CItJcWPdH409b7SAXIIG6p8NdU/4U2Maww==",
-      "dev": true,
-      "requires": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
-      }
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
     },
-    "@types/supertest": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.11.tgz",
-      "integrity": "sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==",
-      "dev": true,
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
       "requires": {
-        "@types/superagent": "*"
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "@types/yargs": {
@@ -9289,6 +9036,17 @@
         "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -9346,6 +9104,17 @@
         "is-glob": "^4.0.3",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/visitor-keys": {
@@ -9684,6 +9453,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -9692,20 +9466,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -9733,9 +9493,9 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.0.tgz",
-      "integrity": "sha512-ER2M0g5iAR84fS/zjBDqEgU6iO5fS9JI2EkHr5zxDxYEFk3LjhU9Vpp/INb6RMQphxko7PDV1FH38H/qVP5yCA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+      "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
       "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001280",
@@ -9764,9 +9524,21 @@
       }
     },
     "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.4.tgz",
+      "integrity": "sha512-wIt0bPACnx8Ju9r6IsS2wVtGDHBr9Dxb+U29A1YED2pu8XOhS8aKjOnLZ8sxyXkPwanoK7iWWVhS1+coxde6xA==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -9791,16 +9563,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -9814,9 +9576,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001280",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-      "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
+      "version": "1.0.30001282",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
+      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
       "dev": true
     },
     "capture-exit": {
@@ -10020,12 +9782,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
-      "dev": true
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -10033,9 +9789,10 @@
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "coveralls": {
       "version": "3.1.1",
@@ -10172,9 +9929,9 @@
       "dev": true
     },
     "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -10240,9 +9997,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.896",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.896.tgz",
-      "integrity": "sha512-NcGkBVXePiuUrPLV8IxP43n1EOtdg+dudVjrfVEUd/bOqpQUFZ2diL5PPYzbgEhZFEltdXV3AcyKwGnEQ5lhMA==",
+      "version": "1.3.901",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.901.tgz",
+      "integrity": "sha512-ToJdV2vzwT2jeAsw8zIggTFllJ4Kxvwghk39AhJEHHlIxor10wsFI3wo69p8nFc0s/ATWBqugPv/k3nW4Y9Mww==",
       "dev": true
     },
     "emittery": {
@@ -10799,12 +10556,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
-    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -10890,12 +10641,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "dev": true
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -10941,17 +10686,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -11071,12 +10805,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-value": {
@@ -11204,6 +10932,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
@@ -11249,7 +10982,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
@@ -11405,7 +11139,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -12330,12 +12065,6 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
-    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -12345,12 +12074,6 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
-    },
-    "mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true
     },
     "mime-db": {
       "version": "1.51.0",
@@ -12405,45 +12128,61 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.4.tgz",
+      "integrity": "sha512-Cv/sk8on/tpvvqbEvR1h03mdyNdyvvO+WhtFlL4jrZ+DSsN/oSQHVqmJQI/sBCqqbOArFcYCAYDfyzqFwV4GSQ==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "bson": "^4.5.4",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.1.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
+      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       },
       "dependencies": {
-        "optional-require": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-          "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
           "requires": {
-            "require-at": "^1.0.6"
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
           }
         }
       }
     },
     "mongoose": {
-      "version": "5.13.13",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.13.tgz",
-      "integrity": "sha512-M55tpCr/p5i6vdJ54nm4MG6/7SKV4JqlWnqbx6yCRuAuW05CZ7u+gNuHVPQVF9dZ59ALXjOtPEUl+OXklAa7ng==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.0.13.tgz",
+      "integrity": "sha512-/M/YKgx23fCX+j0lwObaHbCibXnMjyWeQrXZf0WaQeS/hL86wQVSmaOxh+kZXfyLOUr+vT2Hl44o50GZHUrKWw==",
       "requires": {
-        "@types/bson": "1.x || 4.0.x",
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
+        "bson": "^4.2.2",
         "kareem": "2.3.2",
-        "mongodb": "3.7.3",
-        "mongoose-legacy-pluralize": "1.0.2",
+        "mongodb": "4.1.4",
         "mpath": "0.8.4",
-        "mquery": "3.2.5",
+        "mquery": "4.0.0",
         "ms": "2.1.2",
-        "optional-require": "1.0.x",
         "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
         "sift": "13.5.2",
         "sliced": "1.0.1"
       },
@@ -12452,19 +12191,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
-    },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "requires": {}
     },
     "mpath": {
       "version": "0.8.4",
@@ -12472,30 +12200,13 @@
       "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
     },
     "mquery": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
-      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.0.tgz",
+      "integrity": "sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
+        "debug": "4.x",
         "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "ms": {
@@ -12682,12 +12393,6 @@
         }
       }
     },
-    "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -12723,11 +12428,6 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
-    },
-    "optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -12932,11 +12632,6 @@
         }
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -12972,8 +12667,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -13030,20 +12724,6 @@
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "regex-not": {
@@ -13142,11 +12822,6 @@
         }
       }
     },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13237,7 +12912,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -13577,17 +13253,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
     },
     "sift": {
       "version": "13.5.2",
@@ -13982,14 +13647,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -14043,57 +13700,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "superagent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
-      "dev": true,
-      "requires": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
-        "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-          "dev": true,
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
-    "supertest": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.6.tgz",
-      "integrity": "sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==",
-      "dev": true,
-      "requires": {
-        "methods": "^1.1.2",
-        "superagent": "^6.1.0"
-      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -14278,15 +13884,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -14425,11 +14022,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -14481,14 +14073,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      },
-      "dependencies": {
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        }
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -18,20 +18,18 @@
   "types": "index.d.ts",
   "dependencies": {
     "@elastic/elasticsearch": "7.13.0",
-    "lodash": "4.17.21",
-    "mongoose": "5.13.13"
+    "lodash": "^4.17.21",
+    "mongoose": "^6.0.13"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",
     "@types/lodash": "4.14.176",
     "@types/node": "16.11.7",
-    "@types/supertest": "2.0.11",
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",
     "coveralls": "3.1.1",
     "eslint": "8.2.0",
     "jest": "26.6.3",
-    "supertest": "6.1.6",
     "ts-jest": "26.5.6",
     "ts-node": "10.4.0",
     "typescript": "4.4.4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@elastic/elasticsearch": "7.13.0",
+    "@elastic/elasticsearch": "^7.15.0",
     "lodash": "^4.17.21",
     "mongoose": "^6.0.13"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@elastic/elasticsearch": "^7.15.0",
-    "lodash": "^4.17.21",
-    "mongoose": "^6.0.13"
+    "@elastic/elasticsearch": "7.15.0",
+    "lodash": "4.17.21",
+    "mongoose": "6.0.13"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",

--- a/test/alternative-index-method.test.ts
+++ b/test/alternative-index-method.test.ts
@@ -5,7 +5,7 @@ import { Tweet } from './models/tweet'
 describe('Index Method', function () {
 
   beforeAll(async function () {
-    await mongoose.connect(config.mongoUrl, config.mongoOpts)
+    await mongoose.connect(config.mongoUrl)
     await config.deleteIndexIfExists(['tweets', 'public_tweets'])
 
     await Tweet.deleteMany()

--- a/test/boost-field.test.ts
+++ b/test/boost-field.test.ts
@@ -5,7 +5,7 @@ import { config } from './config'
 
 const esClient = config.getClient()
 
-const TweetSchema = new Schema<MongoosasticDocument>({
+const TweetSchema = new Schema({
   user: String,
   post_date: {
     type: Date,

--- a/test/bulk.test.ts
+++ b/test/bulk.test.ts
@@ -7,7 +7,7 @@ interface IBook extends MongoosasticDocument {
   title: string
 }
 
-const BookSchema = new Schema<MongoosasticDocument>({
+const BookSchema = new Schema({
   title: String
 })
 

--- a/test/config.ts
+++ b/test/config.ts
@@ -70,11 +70,7 @@ function bookTitlesArray(): Array<string> {
 
 export const config = {
   mongoUrl: 'mongodb://localhost/mongoosastic-test',
-  mongoOpts: {
-    useNewUrlParser: true,
-    useFindAndModify: false,
-    useUnifiedTopology: true
-  },
+  mongoOpts: {},
   INDEXING_TIMEOUT,
   BULK_ACTION_TIMEOUT,
   sleep,

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -8,7 +8,7 @@ interface IDummy extends MongoosasticDocument {
   text: string
 }
 
-const DummySchema = new Schema<MongoosasticDocument>({
+const DummySchema = new Schema({
   text: String
 })
 

--- a/test/count.test.ts
+++ b/test/count.test.ts
@@ -10,7 +10,7 @@ interface IComment extends MongoosasticDocument {
   title: string
 }
 
-const CommentSchema = new Schema<MongoosasticDocument>({
+const CommentSchema = new Schema({
   user: String,
   post_date: {
     type: Date,

--- a/test/custom-mapping.test.ts
+++ b/test/custom-mapping.test.ts
@@ -9,7 +9,7 @@ interface IPhone extends MongoosasticDocument {
 }
 
 // -- Only index specific field
-const PhoneSchema = new Schema<MongoosasticDocument>({
+const PhoneSchema = new Schema({
   name: {
     type: String,
     es_indexed: true

--- a/test/custom-serialize.test.ts
+++ b/test/custom-serialize.test.ts
@@ -8,7 +8,7 @@ interface IFood extends MongoosasticDocument {
   type: string
 }
 
-const FoodSchema = new Schema<MongoosasticDocument>({
+const FoodSchema = new Schema({
   name: {
     type: String
   }

--- a/test/filtering.test.ts
+++ b/test/filtering.test.ts
@@ -9,7 +9,7 @@ interface IMovie extends MongoosasticDocument {
 }
 
 // -- Only index specific field
-const MovieSchema = new Schema<MongoosasticDocument>({
+const MovieSchema = new Schema({
   title: {
     type: String,
     required: true,
@@ -64,7 +64,7 @@ describe('Filter mode', function () {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore: callback type
-  it('should not index action genre', async function (done) {
+  it('should not index action genre', async function () {
 
     await config.createModelAndSave(Movie, {
       title: 'Man in Black',
@@ -78,7 +78,6 @@ describe('Filter mode', function () {
     })
 
     expect(results?.body.hits.total).toEqual(0)
-    done()
   })
 
   it('should unindex filtered models', async function () {

--- a/test/filtering.test.ts
+++ b/test/filtering.test.ts
@@ -62,8 +62,6 @@ describe('Filter mode', function () {
     expect(results?.body.hits.total).toEqual(1)
   })
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore: callback type
   it('should not index action genre', async function () {
 
     await config.createModelAndSave(Movie, {

--- a/test/force-index-refresh.test.ts
+++ b/test/force-index-refresh.test.ts
@@ -9,10 +9,10 @@ interface IDummy extends MongoosasticDocument {
   text: string;
 }
 
-const DummySchema = new Schema<MongoosasticDocument>({
+const DummySchema = new Schema({
   text: String
 })
-const DummySchemaRefresh = new Schema<MongoosasticDocument>({
+const DummySchemaRefresh = new Schema({
   text: String
 })
 DummySchema.plugin(mongoosastic, {

--- a/test/geo-bounding-box.test.ts
+++ b/test/geo-bounding-box.test.ts
@@ -1,4 +1,3 @@
-import { QueryContainer } from '@elastic/elasticsearch/api/types'
 import mongoose, { Schema } from 'mongoose'
 import mongoosastic from '../lib/index'
 import { MongoosasticDocument, MongoosasticModel } from '../lib/types'
@@ -137,7 +136,7 @@ describe('Geo Bounding Box Test', function () {
     }
 
     await config.sleep(config.INDEXING_TIMEOUT)
-    const res = await GeoBoundingBoxModel.search(geoQuery as QueryContainer)
+    const res = await GeoBoundingBoxModel.search(geoQuery)
 
     expect(res?.body.hits.total).toEqual(2)
   })

--- a/test/geo-bounding-box.test.ts
+++ b/test/geo-bounding-box.test.ts
@@ -4,7 +4,7 @@ import mongoosastic from '../lib/index'
 import { MongoosasticDocument, MongoosasticModel } from '../lib/types'
 import { config } from './config'
 
-const GeoBoundingBoxSchema = new Schema<MongoosasticDocument>({
+const GeoBoundingBoxSchema = new Schema({
   text: {
     type: String,
     es_indexed: true

--- a/test/geo.test.ts
+++ b/test/geo.test.ts
@@ -14,7 +14,7 @@ interface IGeo extends MongoosasticDocument {
   }
 }
 
-const GeoSchema = new Schema<MongoosasticDocument>({
+const GeoSchema = new Schema({
   myId: Number,
   frame: {
     coordinates: [],

--- a/test/highlight.test.ts
+++ b/test/highlight.test.ts
@@ -8,7 +8,7 @@ interface IText extends MongoosasticDocument {
   quote: string
 }
 
-const TextSchema = new Schema<MongoosasticDocument>({
+const TextSchema = new Schema({
   title: String,
   quote: String
 })

--- a/test/hydrate-preserves-ordering.test.ts
+++ b/test/hydrate-preserves-ordering.test.ts
@@ -8,7 +8,7 @@ interface IRank extends MongoosasticDocument {
   rank: number
 }
 
-const rankSchema = new Schema<MongoosasticDocument>({
+const rankSchema = new Schema({
   title: String,
   rank: Number
 })

--- a/test/hydrate-with-es-results.test.ts
+++ b/test/hydrate-with-es-results.test.ts
@@ -8,7 +8,7 @@ interface IText extends MongoosasticDocument {
   quote: string
 }
 
-const textSchema = new Schema<MongoosasticDocument>({
+const textSchema = new Schema({
   title: String,
   quote: String
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -358,8 +358,6 @@ describe('indexing', function () {
 
   describe('Isolated Models', function () {
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore: callback type
     beforeAll(async function () {
       const talk = new Talk({
         speaker: '',
@@ -579,8 +577,6 @@ describe('indexing', function () {
 
   describe('Disable automatic indexing', function () {
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore: callback type
     it('should save but not index', async function () {
       const newDog = new Dog({ name: 'Sparky' })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,3 @@
-import { QueryContainer } from '@elastic/elasticsearch/api/types'
 import mongoose, { Schema } from 'mongoose'
 import mongoosastic from '../lib/index'
 import { MongoosasticDocument, MongoosasticModel } from '../lib/types'
@@ -261,7 +260,8 @@ describe('indexing', function () {
     it('should report errors', async function () {
       await Tweet.search({
         queriez: 'jamescarr'
-      } as QueryContainer)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any) // We used 'any' since we are testing the case of passing an incorrect queries
         .then(results => expect(results).toBeFalsy())
         .catch(error => expect(error.message).toMatch(/(SearchPhaseExecutionException|parsing_exception)/))
     })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,7 +16,7 @@ interface ITalk extends MongoosasticDocument {
 }
 
 // -- Only index specific field
-const TalkSchema = new Schema<MongoosasticDocument>({
+const TalkSchema = new Schema({
   speaker: String,
   year: {
     type: Number,
@@ -37,7 +37,7 @@ interface IBum extends MongoosasticDocument {
   name: string
 }
 
-const BumSchema = new Schema<MongoosasticDocument>({
+const BumSchema = new Schema({
   name: String
 })
 
@@ -51,7 +51,7 @@ interface IPerson extends MongoosasticDocument {
   }
 }
 
-const PersonSchema = new Schema<MongoosasticDocument>({
+const PersonSchema = new Schema({
   name: {
     type: String,
     es_indexed: true
@@ -73,7 +73,7 @@ const PersonSchema = new Schema<MongoosasticDocument>({
   }
 })
 
-const DogSchema = new Schema<MongoosasticDocument>({
+const DogSchema = new Schema({
   name: { type: String, es_indexed: true }
 })
 
@@ -360,7 +360,7 @@ describe('indexing', function () {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: callback type
-    beforeAll(async function (done) {
+    beforeAll(async function () {
       const talk = new Talk({
         speaker: '',
         year: 2013,
@@ -377,8 +377,11 @@ describe('indexing', function () {
       await tweet.save()
       await talk.save()
 
-      talk.on('es-indexed', function () {
-        setTimeout(done, config.INDEXING_TIMEOUT as number)
+      await new Promise((resolve) => {
+        talk.on('es-indexed', async function() {
+          await config.sleep(config.INDEXING_TIMEOUT)
+          resolve(talk)
+        })
       })
     })
 
@@ -578,7 +581,7 @@ describe('indexing', function () {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: callback type
-    it('should save but not index', async function (done) {
+    it('should save but not index', async function () {
       const newDog = new Dog({ name: 'Sparky' })
 
       let whoopsIndexed = false
@@ -589,10 +592,9 @@ describe('indexing', function () {
         whoopsIndexed = true
       })
 
-      setTimeout(function () {
-        expect(whoopsIndexed).toBeFalsy()
-        done()
-      }, config.INDEXING_TIMEOUT)
+      await config.sleep(config.INDEXING_TIMEOUT)
+      expect(whoopsIndexed).toBeFalsy()
+
     })
   })
 })

--- a/test/mapping.test.ts
+++ b/test/mapping.test.ts
@@ -15,7 +15,7 @@ interface ISchema extends MongoosasticDocument {
   },
 }
 
-const schema = new Schema<MongoosasticDocument>({
+const schema = new Schema({
   string: String,
   mixed_field: {
     type: mongoose.Schema.Types.Mixed
@@ -60,7 +60,7 @@ describe('MappingGenerator', function () {
     })
 
     it('maps field with simple text type', function (done) {
-      const schema = new Schema<MongoosasticDocument>({ name: String })
+      const schema = new Schema({ name: String })
       const mapping = generator.generateMapping(schema)
 
       expect(mapping.properties.name.type).toEqual('text')
@@ -68,7 +68,7 @@ describe('MappingGenerator', function () {
     })
 
     it('maps field with text type attribute', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: String
         }
@@ -80,7 +80,7 @@ describe('MappingGenerator', function () {
     })
 
     it('converts Date type to date', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         graduationDate: {
           type: Date,
           es_format: 'YYYY-MM-dd'
@@ -93,7 +93,7 @@ describe('MappingGenerator', function () {
     })
 
     it('removes _id field without prefix', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         _id: {
           type: Schema.Types.ObjectId
         },
@@ -113,7 +113,7 @@ describe('MappingGenerator', function () {
     })
 
     it('does not remove _id field with prefix', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         _id: {
           type: Schema.Types.ObjectId
         },
@@ -133,7 +133,7 @@ describe('MappingGenerator', function () {
     })
 
     it('converts object id to text if not _id', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         oid: {
           type: Schema.Types.ObjectId
         }
@@ -145,7 +145,7 @@ describe('MappingGenerator', function () {
     })
 
     it('does not modify the original schema tree', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         oid: Schema.Types.ObjectId
       })
       const mapping = generator.generateMapping(schema)
@@ -156,7 +156,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an object and maps it as one', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         contact: {
           email: {
             type: String
@@ -174,7 +174,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an object and handles explict es_indexed', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: String,
           es_indexed: true
@@ -205,7 +205,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes a nested schema and handles explict es_indexed', function (done) {
-      const ContactSchema = new Schema<MongoosasticDocument>({
+      const ContactSchema = new Schema({
         email: {
           type: String,
           es_indexed: true
@@ -220,7 +220,7 @@ describe('MappingGenerator', function () {
         }
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: String,
           es_indexed: true
@@ -242,7 +242,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an multi_field and maps it as one', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         test: {
           type: String,
           es_include_in_all: false,
@@ -271,7 +271,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an geo_point and maps it as one', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         geo: {
           type: String,
           es_type: 'geo_point'
@@ -285,7 +285,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an geo_point with independent lat lon fields and maps it as one', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         geo_with_lat_lon: {
           geo_point: {
             type: String,
@@ -309,7 +309,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an nested schema and maps it', function (done) {
-      const NameSchema = new Schema<MongoosasticDocument>({
+      const NameSchema = new Schema({
         first_name: {
           type: String
         },
@@ -318,7 +318,7 @@ describe('MappingGenerator', function () {
         }
       })
 
-      const schema = new Schema<MongoosasticDocument>({ name: [NameSchema] })
+      const schema = new Schema({ name: [NameSchema] })
       const mapping = generator.generateMapping(schema)
 
       expect(mapping.properties.name.type).toEqual('object')
@@ -328,7 +328,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes an es_type of nested with es_fields and maps it', function (done) {
-      const NameSchema = new Schema<MongoosasticDocument>({
+      const NameSchema = new Schema({
         first_name: {
           type: String,
           es_index: 'not_analyzed'
@@ -339,7 +339,7 @@ describe('MappingGenerator', function () {
         }
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: [NameSchema],
           es_indexed: true,
@@ -362,7 +362,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes a nested array with a simple type and maps it as a simple attribute', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         contacts: [String]
       })
 
@@ -373,7 +373,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes a nested array with a simple type and additional attributes and maps it as a simple attribute', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         contacts: [{
           type: String,
           es_index: 'not_analyzed'
@@ -388,7 +388,7 @@ describe('MappingGenerator', function () {
     })
 
     it('recognizes a nested array with a complex object and maps it', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: String,
         contacts: [{
           email: {
@@ -415,7 +415,7 @@ describe('MappingGenerator', function () {
         age: number,
       }
 
-      const PersonSchema = new Schema<MongoosasticDocument>({
+      const PersonSchema = new Schema({
         first_name: {
           type: String
         },
@@ -431,7 +431,7 @@ describe('MappingGenerator', function () {
         this.age = new Date().getFullYear() - year
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: [PersonSchema]
       })
 
@@ -464,7 +464,7 @@ describe('MappingGenerator', function () {
 
   describe('elastic search fields', function () {
     it('type can be overridden', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: String,
           es_type: 'date'
@@ -478,7 +478,7 @@ describe('MappingGenerator', function () {
     })
 
     it('adds the boost field', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: String,
           es_boost: 2.2
@@ -492,7 +492,7 @@ describe('MappingGenerator', function () {
     })
 
     it('respects schemas with explicit es_indexes', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         implicit_field_1: {
           type: String
         },
@@ -528,7 +528,7 @@ describe('MappingGenerator', function () {
     })
 
     it('make sure id is mapped', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: String
         },
@@ -551,7 +551,7 @@ describe('MappingGenerator', function () {
     })
 
     it('maps all fields when schema has no es_indexed flag', function (done) {
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         implicit_field_1: {
           type: String
         },
@@ -570,12 +570,12 @@ describe('MappingGenerator', function () {
 
   describe('ref mapping', function () {
     it('maps all fields from referenced schema', function (done) {
-      const Name = new Schema<MongoosasticDocument>({
+      const Name = new Schema({
         firstName: String,
         lastName: String
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: { type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name }
       })
 
@@ -587,12 +587,12 @@ describe('MappingGenerator', function () {
     })
 
     it('maps only selected fields from referenced schema', function (done) {
-      const Name = new Schema<MongoosasticDocument>({
+      const Name = new Schema({
         firstName: String,
         lastName: String
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: { type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName' }
       })
 
@@ -604,12 +604,12 @@ describe('MappingGenerator', function () {
     })
 
     it('maps all fields from array of referenced schema', function (done) {
-      const Name = new Schema<MongoosasticDocument>({
+      const Name = new Schema({
         firstName: String,
         lastName: String
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name }],
           es_type: 'object'
@@ -624,12 +624,12 @@ describe('MappingGenerator', function () {
     })
 
     it('maps only selected fields from array of referenced schema', function (done) {
-      const Name = new Schema<MongoosasticDocument>({
+      const Name = new Schema({
         firstName: String,
         lastName: String
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         name: {
           type: [{ type: Schema.Types.ObjectId, ref: 'Name', es_schema: Name, es_select: 'firstName' }],
           es_type: 'object'
@@ -644,7 +644,7 @@ describe('MappingGenerator', function () {
     })
 
     it('maps a geo_point field of an nested referenced schema as a geo_point', function (done) {
-      const Location = new Schema<MongoosasticDocument>({
+      const Location = new Schema({
         name: String,
         coordinates: {
           type: {
@@ -661,7 +661,7 @@ describe('MappingGenerator', function () {
         }
       })
 
-      const schema = new Schema<MongoosasticDocument>({
+      const schema = new Schema({
         locations: {
           type: [{ type: Schema.Types.ObjectId, ref: 'Location', es_schema: Location }],
           es_type: 'object'

--- a/test/mapping.test.ts
+++ b/test/mapping.test.ts
@@ -647,17 +647,13 @@ describe('MappingGenerator', function () {
       const Location = new Schema({
         name: String,
         coordinates: {
-          type: {
-            geo_point: {
-              type: String,
-              es_type: 'geo_point',
-              es_lat_lon: true
-            },
-
-            lat: { type: Number, default: 0 },
-            lon: { type: Number, default: 0 }
+          geo_point: {
+            type: String,
+            es_type: 'geo_point',
+            es_lat_lon: true
           },
-          es_type: 'geo_point'
+          lat: { type: Number, default: 0 },
+          lon: { type: Number, default: 0 },
         }
       })
 

--- a/test/models/tweet.ts
+++ b/test/models/tweet.ts
@@ -1,8 +1,8 @@
-import mongoose, { Schema } from 'mongoose'
+import mongoose, { Document, Schema } from 'mongoose'
 import mongoosastic from '../../lib/index'
 import { MongoosasticDocument, MongoosasticModel } from '../../lib/types'
 
-export interface ITweet extends MongoosasticDocument {
+export interface ITweet extends Document, MongoosasticDocument {
   user: string,
   userId: number,
   post_date: Date,
@@ -10,7 +10,7 @@ export interface ITweet extends MongoosasticDocument {
 }
 
 // -- simplest indexing... index all fields
-const TweetSchema = new Schema<MongoosasticDocument>({
+const TweetSchema = new Schema({
   user: String,
   userId: Number,
   post_date: Date,

--- a/test/ref.test.ts
+++ b/test/ref.test.ts
@@ -31,7 +31,7 @@ interface IPost extends MongoosasticDocument {
   comments: IPostComment,
 }
 
-const PostSchema = new Schema<MongoosasticDocument>({
+const PostSchema = new Schema({
   body: { type: String, es_indexed: true },
   author: { type: Schema.Types.ObjectId, ref: 'User', es_schema: UserSchema, es_indexed: true },
   comments: [{ type: Schema.Types.ObjectId, ref: 'PostComment', es_schema: PostCommentSchema, es_indexed: true }]

--- a/test/refresh.test.ts
+++ b/test/refresh.test.ts
@@ -7,7 +7,7 @@ interface IRefresh extends MongoosasticDocument {
   title: string
 }
 
-const RefreshSchema = new Schema<MongoosasticDocument>({
+const RefreshSchema = new Schema({
   title: String
 })
 

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -7,7 +7,7 @@ interface ITask extends MongoosasticDocument {
   content: string
 }
 
-const TaskSchema = new Schema<MongoosasticDocument>({
+const TaskSchema = new Schema({
   content: String
 })
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,4 +1,4 @@
-import { Aggregate, Hit } from '@elastic/elasticsearch/api/types'
+import { AggregationsAggregate, SearchHit } from '@elastic/elasticsearch/api/types'
 import mongoose, { Schema } from 'mongoose'
 import mongoosastic from '../lib/index'
 import { MongoosasticDocument, MongoosasticModel } from '../lib/types'
@@ -70,8 +70,8 @@ describe('Query DSL', function () {
       const res = await Bond.search({
         range: {
           price: {
-            from: 20000,
-            to: 30000
+            gte: 20000,
+            lte: 30000
           }
         }
       })
@@ -85,7 +85,7 @@ describe('Query DSL', function () {
   })
 
   describe('Sort', function () {
-    const getNames = function (res: Hit<IBond>) {
+    const getNames = function (res: SearchHit<IBond>) {
       return res._source?.name
     }
     const expectedDesc = ['Legal', 'Construction', 'Commercial', 'Bail']
@@ -166,7 +166,7 @@ describe('Query DSL', function () {
           }
         })
 
-        expect(res?.body.aggregations?.names['buckets' as keyof Aggregate]).toEqual([
+        expect(res?.body.aggregations?.names['buckets' as keyof AggregationsAggregate]).toEqual([
           {
             doc_count: 1,
             key: 'Bail'
@@ -190,7 +190,7 @@ describe('Query DSL', function () {
 
   describe('Fuzzy search', function () {
     it('should do a fuzzy query', async function () {
-      const getNames = function (res: Hit<IBond>) {
+      const getNames = function (res: SearchHit<IBond>) {
         return res._source?.name
       }
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -10,7 +10,7 @@ interface IBond extends MongoosasticDocument {
   price: number
 }
 
-const BondSchema = new Schema<MongoosasticDocument>({
+const BondSchema = new Schema({
   name: String,
   type: {
     type: String,

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -26,7 +26,7 @@ interface IPerson extends MongoosasticDocument {
 }
 
 const BowlingBall = mongoose.model('BowlingBall', new Schema())
-const PersonSchema = new Schema<MongoosasticDocument>({
+const PersonSchema = new Schema({
   name: {
     first: String,
     last: String

--- a/test/suggesters.test.ts
+++ b/test/suggesters.test.ts
@@ -10,7 +10,7 @@ interface IKitten extends MongoosasticDocument {
   breed: string
 }
 
-const KittenSchema = new Schema<MongoosasticDocument>({
+const KittenSchema = new Schema({
   name: {
     type: String,
     es_type: 'completion',

--- a/test/synchronize.test.ts
+++ b/test/synchronize.test.ts
@@ -7,7 +7,7 @@ interface IBook extends MongoosasticDocument {
   title: string,
 }
 
-const BookSchema = new Schema<MongoosasticDocument>({
+const BookSchema = new Schema({
   title: {
     type: String,
     required: true

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -10,7 +10,7 @@ interface IRepo extends MongoosasticDocument {
 }
 
 // -- Only index specific field
-const RepoSchema = new Schema<MongoosasticDocument>({
+const RepoSchema = new Schema({
   name: {
     type: String,
     es_indexed: true

--- a/test/truncate.test.ts
+++ b/test/truncate.test.ts
@@ -7,7 +7,7 @@ interface IDummy extends MongoosasticDocument {
   text: string
 }
 
-const DummySchema = new Schema<MongoosasticDocument>({
+const DummySchema = new Schema({
   text: String
 })
 
@@ -39,7 +39,7 @@ describe('Truncate', function () {
     it('should be able to truncate all documents', async function () {
 
       await Dummy.esTruncate()
-      await config.sleep(config.INDEXING_TIMEOUT)
+      await config.sleep(config.BULK_ACTION_TIMEOUT)
 
       const results = await Dummy.search({
         query_string: {


### PR DESCRIPTION
## Update dependencies

Checklist: #576.

* Update `Mongoose` to `v6.0.13`:
    * Fix: change population function in `postSave` hook.
    * Fix the failed test `map a geo_point field of an nested referenced schema as a geo_point` in `mapping.test.ts` due to the package update.
* Update `@elastic/elasticsearch` to `v7.15.0`:
    * Fix: update the renamed types/interfaces.
* Update `lodash` to `v4.17.21`.