### PR TITLE
adding `type`  to bulk operations which is now required by elasticsearch

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -300,6 +300,7 @@ function Mongoosastic (schema, pluginOpts) {
     bulkAdd({
       delete: {
         _index: opts.index || indexName,
+        _type: opts.type || typeName,
         _id: opts.model._id.toString(),
         routing: opts.routing
       }
@@ -311,6 +312,7 @@ function Mongoosastic (schema, pluginOpts) {
     bulkAdd({
       index: {
         _index: opts.index || indexName,
+        _type: opts.type || typeName,
         _id: opts._id.toString(),
         routing: opts.routing
       }

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -683,7 +683,7 @@ function Mongoosastic (schema, pluginOpts) {
 
   function reformatESTotalNumber (res) {
     Object.assign(res.hits, {
-      total: res.hits.total.value,
+      total: res.hits.total.value || res.hits.total,
       extTotal: res.hits.total
     })
     return res


### PR DESCRIPTION
When attempting to "index" a record, I get the following error message:

```
{
  "error": {
    "root_cause": [{
      "type": "action_request_validation_exception",
      "reason":"Validation Failed: 1: type is missing;"
    }],
  //...
```