### PR TITLE
Integrate github actions CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,3 @@
- 
-
 {
   "extends": [
     "config:base"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+on:
+  push:
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "package.json"
+      - "package-lock.json"
+  pull_request:
+    types: [opened]
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "package.json"
+      - "package-lock.json"
+    branches:
+      - "!*"
+      - "develop"
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+
+    strategy:
+      matrix:
+        elasticsearch-version: [7.15.0]
+
+    steps:
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: ${{ matrix.elasticsearch-version }}
+
+      - uses: actions/checkout@v2
+        with:
+          # checkout full tree
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - run: npm install
+      - run: npm test

--- a/lib/statics.ts
+++ b/lib/statics.ts
@@ -1,5 +1,5 @@
-import { MappingProperty, PropertyName, QueryDslQueryContainer } from '@elastic/elasticsearch/api/types'
-import { ApiResponse, RequestBody } from '@elastic/elasticsearch/lib/Transport'
+import { IndicesCreateRequest, MappingProperty, PropertyName, QueryDslQueryContainer } from '@elastic/elasticsearch/api/types'
+import { ApiResponse } from '@elastic/elasticsearch/lib/Transport'
 import { EventEmitter } from 'events'
 import { FilterQuery } from 'mongoose'
 import { postSave } from './hooks'
@@ -9,7 +9,7 @@ import { filterMappingFromMixed, getIndexName } from './utils'
 
 export async function createMapping(
   this: MongoosasticModel<MongoosasticDocument>,
-  body: RequestBody
+  body: IndicesCreateRequest['body']
 ): Promise<Record<PropertyName, MappingProperty>> {
   const options = this.esOptions()
   const client = this.esClient()
@@ -44,14 +44,11 @@ export async function createMapping(
 
   await client.indices.create({
     index: indexName,
-    body: body,
+    body: {
+      mappings: completeMapping,
+      ...body
+    },
   })
-
-  await client.indices.putMapping({
-    index: indexName,
-    body: completeMapping,
-  })
-
   return completeMapping
 }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -2,6 +2,7 @@
 import { ApiResponse, Client, ClientOptions } from '@elastic/elasticsearch'
 import {
   CountResponse,
+  IndicesCreateRequest,
   IndicesRefreshResponse,
   MappingProperty,
   MappingTypeMapping,
@@ -13,7 +14,6 @@ import {
   SearchRequest,
   SearchResponse,
 } from '@elastic/elasticsearch/api/types'
-import { RequestBody } from '@elastic/elasticsearch/lib/Transport'
 import { EventEmitter } from 'events'
 import { Document, Model, PopulateOptions, QueryOptions } from 'mongoose'
 
@@ -144,7 +144,7 @@ declare interface MongoosasticDocument<TDocument = any> extends Document<TDocume
 interface MongoosasticModel<T> extends Model<T> {
   bulkError(): EventEmitter;
 
-  createMapping(body?: RequestBody): Promise<Record<PropertyName, MappingProperty>>;
+  createMapping(body?: IndicesCreateRequest['body']): Promise<Record<PropertyName, MappingProperty>>;
 
   esClient(): Client;
 

--- a/test/boost-field.test.ts
+++ b/test/boost-field.test.ts
@@ -16,6 +16,7 @@ const TweetSchema = new Schema({
   },
   title: {
     type: String,
+    // Should comment the next option to work with ES v8.X
     es_boost: 2.0
   }
 })
@@ -48,6 +49,7 @@ describe('Add Boost Option Per Field', function () {
     const props = mapping.body.blogposts.mappings.properties
 
     expect(props.title.type).toEqual('text')
+    // Should comment the next line to work with ES v8.X
     expect(props.title.boost).toEqual(2.0)
   })
 })

--- a/test/config.ts
+++ b/test/config.ts
@@ -6,7 +6,7 @@ import { MongoosasticDocument, MongoosasticModel } from '../lib/types'
 const esClient = new Client({ node: 'http://localhost:9200' })
 
 const INDEXING_TIMEOUT: number = toInteger(process.env.INDEXING_TIMEOUT) || 2000
-const BULK_ACTION_TIMEOUT: number = toInteger(process.env.BULK_ACTION_TIMEOUT) || 4000
+const BULK_ACTION_TIMEOUT: number = toInteger(process.env.BULK_ACTION_TIMEOUT) || 5000
 
 function sleep(time: number): Promise<unknown> {
   return new Promise((resolve) => setTimeout(resolve, time))

--- a/test/geo-bounding-box.test.ts
+++ b/test/geo-bounding-box.test.ts
@@ -67,7 +67,7 @@ describe('Geo Bounding Box Test', function () {
     for (const point of points) {
       await point.save()
     }
-    await config.sleep(config.INDEXING_TIMEOUT)
+    await config.sleep(config.BULK_ACTION_TIMEOUT)
 
     const res = await GeoBoundingBoxModel.find({})
     expect(res.length).toEqual(3)

--- a/test/geo.test.ts
+++ b/test/geo.test.ts
@@ -24,6 +24,7 @@ const GeoSchema = new Schema({
     geo_shape: {
       type: String,
       es_type: 'geo_shape',
+      // Should comment the next three options to work with ES v8.X
       es_tree: 'quadtree',
       es_precision: '1km',
       es_distance_error_pct: '0.001'

--- a/test/hydrate-with-es-results.test.ts
+++ b/test/hydrate-with-es-results.test.ts
@@ -47,7 +47,7 @@ describe('Hydrate with ES data', function () {
     for (const text of texts) {
       await config.saveAndWaitIndex(text)
     }
-    await config.sleep(config.INDEXING_TIMEOUT)
+    await config.sleep(config.BULK_ACTION_TIMEOUT)
   })
 
   afterAll(async function () {
@@ -101,6 +101,7 @@ describe('Hydrate with ES data', function () {
         expect(text._esResult?._index).toEqual('texts')
 
         expect(text._esResult).toHaveProperty('_id')
+        // Should comment the next line to work with ES v8.X
         expect(text._esResult).toHaveProperty('_type')
         expect(text._esResult).toHaveProperty('_score')
         expect(text._esResult).toHaveProperty('highlight')
@@ -134,6 +135,7 @@ describe('Hydrate with ES data', function () {
         expect(text._esResult?._index).toEqual('texts')
 
         expect(text._esResult).toHaveProperty('_id')
+        // Should comment the next line to work with ES v8.X
         expect(text._esResult).toHaveProperty('_type')
         expect(text._esResult).toHaveProperty('_score')
         expect(text._esResult).toHaveProperty('highlight')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -122,20 +122,17 @@ describe('indexing', function () {
   })
 
   describe('Creating Index', function () {
-    it('should create index if none exists', async function () {
-      const response = await Tweet.createMapping()
-
-      expect(response).toBeTruthy()
-      expect(response).not.toHaveProperty('error')
-    })
-
     it('should create index with settings if none exists', async function () {
       const response = await Tweet.createMapping({
-        analysis: {
-          analyzer: {
-            stem: {
-              tokenizer: 'standard',
-              filter: ['standard', 'lowercase', 'stop', 'porter_stem']
+        settings: {
+          index: {
+            analysis: {
+              analyzer: {
+                stem: {
+                  tokenizer: 'standard',
+                  filter: ['lowercase']
+                }
+              }
             }
           }
         }
@@ -241,7 +238,7 @@ describe('indexing', function () {
       }]
 
       await Tweet.insertMany(tweets)
-      await config.sleep(config.INDEXING_TIMEOUT)
+      await config.sleep(config.BULK_ACTION_TIMEOUT)
 
       const results = await Tweet.search({
         query_string: {


### PR DESCRIPTION
Checklist: #576.

- [x] Refactor `createMapping` method: instead of creating an index with custom settings, then update it to add the mapping (two separate actions), we specify the settings & the mappings when creating the index (one operation).
- [x] Remove unnecessary/duplicated test in `test/index.test.ts`, testing the `createMapping` method.
- [x] Add github actions CI