### PR TITLE
npm script prepare should be used instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "authors": "./scripts/update_authors.sh",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "rm -rf dist && tsc -p . ",
     "lint-fix": "npm run lint -- --fix",
     "lint": "eslint lib test",


### PR DESCRIPTION
Hi,

npm script prepublish is deprecated https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish and no longer work if using yarn to install the package.

This solves this problem:
https://github.com/mongoosastic/mongoosastic/issues/576#issuecomment-1060009389