### PR TITLE
Allow tranform func to be async

### DIFF
--- a/lib/methods.ts
+++ b/lib/methods.ts
@@ -33,7 +33,7 @@ export async function index(
   }
 
   if (options.transform) {
-    body = options.transform(body, this)
+    body = await options.transform(body, this)
   }
 
   const opt = {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -22,7 +22,7 @@ declare interface FilterFn {
 }
 
 declare interface TransformFn {
-  (body: Record<string, unknown>, doc: Document): any;
+  (body: Record<string, unknown>, doc: Document): Record<string, unknown> | Promise<Record<string, unknown>>;
 }
 
 declare interface RoutingFn {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongoosastic",
-  "version": "5.0.0-rc.3",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongoosastic",
-      "version": "5.0.0-rc.3",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "7.15.0",

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -32,17 +32,36 @@ RepoSchema.plugin(mongoosastic, {
 
 const Repo = mongoose.model<IRepo, MongoosasticModel<IRepo>>('Repo', RepoSchema)
 
+// -- Index with async transform function
+const PodcastSchema = new Schema({name: {type: String, es_indexed: true}})
+
+PodcastSchema.plugin(mongoosastic, {
+  transform: async function (data: Record<string, unknown>) {
+    data.name = await new Promise(
+      resolve => setTimeout(
+        () => resolve('Qwerpline'),
+        50
+      )
+    )
+    return data
+  }
+})
+
+const Podcast = mongoose.model<IRepo, MongoosasticModel<IRepo>>('Podcast', PodcastSchema)
+
 describe('Transform mode', function () {
 
   beforeAll(async function () {
-    await config.deleteIndexIfExists(['repos'])
+    await config.deleteIndexIfExists(['repos', 'podcasts'])
     await mongoose.connect(config.mongoUrl, config.mongoOpts)
     await Repo.deleteMany()
+    await Podcast.deleteMany()
   })
 
   afterAll(async function () {
     await Repo.deleteMany()
-    await config.deleteIndexIfExists(['repos'])
+    await Podcast.deleteMany()
+    await config.deleteIndexIfExists(['repos', 'podcasts'])
     await mongoose.disconnect()
   })
 
@@ -57,6 +76,21 @@ describe('Transform mode', function () {
     const results = await Repo.search({
       query_string: {
         query: 'Apache'
+      }
+    })
+
+    expect(results?.body.hits.total).toEqual(1)
+  })
+
+  it('should wait for promise if transform is async', async function () {
+
+    await config.createModelAndEnsureIndex(Podcast, {
+      name: 'The Fitzroy Diaries'
+    })
+
+    const results = await Podcast.search({
+      query_string: {
+        query: 'Qwerpline'
       }
     })
 


### PR DESCRIPTION
If the user passes in an async function for the transform option then mongoosastic will silently the ditch all fields in the document being indexed in elasticsearch. This is because it doesn't understand that it's an async function and thus doesn't wait for it to resolve. This MR fixes that by respecting the fact that an async function may be given and waits till the promise is resolved.