### PR TITLE
Fix custom properties

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Options are:
 * `transform` - the function used to transform serialized document before indexing
 * `populate` - an Array of Mongoose populate options objects
 * `indexAutomatically` - allows indexing after model save to be disabled for when you need finer control over when documents are indexed. Defaults to true
-* `customProperties` - an object detailing additional properties which will be merged onto the type's default mapping when `createMapping` is called.
+* `properties` - an object detailing additional properties which will be merged onto the type's default mapping when `createMapping` is called (note: [`createMapping`](/mapping#creating-mappings-on-demand) is not called automatically, you must explicitly call it).
 * `saveOnSynchronize` - triggers Mongoose save (and pre-save) method when synchronizing a collection/index. Defaults to true
 
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -15,14 +15,14 @@ import {
   SearchResponse,
 } from '@elastic/elasticsearch/api/types'
 import { EventEmitter } from 'events'
-import { Document, Model, PopulateOptions, QueryOptions } from 'mongoose'
+import { Document, HydratedDocument, Model, PopulateOptions, QueryOptions } from 'mongoose'
 
 declare interface FilterFn {
   (doc: Document): boolean;
 }
 
-declare interface TransformFn {
-  (body: Record<string, unknown>, doc: Document): any;
+declare interface TransformFn<T = any> {
+  (body: Record<string, unknown>, doc: HydratedDocument<T>): any;
 }
 
 declare interface RoutingFn {
@@ -109,7 +109,11 @@ declare type Options = {
   index?: string;
   indexAutomatically?: boolean;
   populate?: PopulateOptions[];
-  properties?: any;
+  properties?: {[key: string]: any};
+  /**
+   * @property {never}  customProperties - The docs incorrectly stated that this option was called "customProperties", use "properties" instead.
+   */
+  customProperties?: never;
   routing?: RoutingFn;
   saveOnSynchronize?: boolean;
   transform?: TransformFn;

--- a/test/config.ts
+++ b/test/config.ts
@@ -33,8 +33,11 @@ async function createModelAndEnsureIndex<T extends MongoosasticDocument>(Model: 
   const doc = new Model(obj)
   await doc.save()
 
-  return new Promise((resolve) => {
-    doc.on('es-indexed', async function () {
+  return new Promise((resolve, reject) => {
+    doc.on('es-indexed', async function (err) {
+      if (err) {
+        return reject(err)
+      }
       await sleep(INDEXING_TIMEOUT)
       resolve(doc)
     })


### PR DESCRIPTION
I don't know how this happened or how I could be the first to run into this but as far as I can tell the "customProperties" option is completely broken and possibly has never worked :/

The docs mention a option called `customProperties` can be passed in but looking at the actual code such an option is never used. A [`properties` option is however used](https://github.com/mongoosastic/mongoosastic/blob/49ff5ba9daf6704f8ac7adcc83392c8033d33687/lib/statics.ts#L26) so I can only assume this what the docs mean to say instead of `customProperties`.

There is a test for `customProperties` but it doesn't work for a number of reasons including the fact that it doesn't call `createMapping()` which the docs state (and I can confirm) is needed for these properties to be used.

I have updated the documentation and fixed + extended the tests.