### PR TITLE
expose bulkAdd

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 import events from 'events'
 import { Schema } from 'mongoose'
-import { flush } from './bulking'
+import { flush, bulkAdd } from './bulking'
 import { createEsClient } from './esClient'
 import { postRemove, postSave } from './hooks'
 import Generator from './mapping'
@@ -40,6 +40,7 @@ function mongoosastic(
   schema.method('index', index)
   schema.method('unIndex', unIndex)
 
+  schema.static('bulkAdd', bulkAdd)
   schema.static('synchronize', synchronize)
   schema.static('esTruncate', esTruncate)
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -167,6 +167,8 @@ interface MongoosasticModel<T> extends Model<T> {
   search(query: QueryDslQueryContainer, options?: EsSearchOptions): Promise<ApiResponse<HydratedSearchResults<T>>>;
 
   synchronize(query?: any, options?: SynchronizeOptions): EventEmitter;
+
+  bulkAdd(opts: BulkIndexOptions): Promise<void>
 }
 
 export {

--- a/test/bulkAdd.test.ts
+++ b/test/bulkAdd.test.ts
@@ -1,0 +1,80 @@
+import mongoose, { Schema } from 'mongoose'
+import mongoosastic from '../lib/index'
+import { MongoosasticDocument, MongoosasticModel } from '../lib/types'
+import { config } from './config'
+
+interface IBook extends MongoosasticDocument {
+  title: string,
+}
+
+const BookSchema = new Schema({
+  title: {
+    type: String,
+    required: true
+  }
+})
+
+BookSchema.plugin(mongoosastic)
+
+const Book = mongoose.model<IBook, MongoosasticModel<IBook>>('Book', BookSchema)
+
+describe('bulkAdd', () => {
+
+  let books
+
+  beforeAll(function () {
+    jest.setTimeout(10000)
+  })
+
+  afterAll(async function () {
+    await Book.deleteMany()
+    await config.deleteIndexIfExists(['books'])
+    await mongoose.disconnect()
+  })
+
+  describe('an existing collection', () => {
+
+    beforeAll(async function () {
+      await config.deleteIndexIfExists(['books'])
+      await mongoose.connect(config.mongoUrl, config.mongoOpts)
+      const client = mongoose.connections[0].db
+      books = client.collection('books')
+
+      await Book.deleteMany()
+
+      for (const title of config.bookTitlesArray()) {
+        await books.insertOne({
+          title: title
+        })
+      }
+    })
+
+    it('should index all existing objects', async () => {
+      for await (const book of Book.find().cursor()) {
+
+        const obj = { title: book.title }
+        await Book.bulkAdd({
+          body: obj,
+          bulk: {
+            size: 1000,
+            batch: 1000,
+            delay: 100,
+          },
+          id: book._id.toString(),
+          index: 'books',
+          model: Book,
+        })
+      }
+
+      await config.sleep(config.BULK_ACTION_TIMEOUT)
+
+
+      const results = await Book.search({
+        query_string: {
+          query: 'American'
+        }
+      })
+      expect(results?.body.hits.total).toEqual(2)
+    })
+  })
+})


### PR DESCRIPTION
i have a problem when i use the synchronize method to sync existing collection to ES with the massive data we have  it took 2 - 3 days and didn't finish or even get close so i exposed the bulkAdd method and it did the job in 15 to 20 minutes sometimes less so as discussed  in the issue https://github.com/mongoosastic/mongoosastic/issues/600
this might be a temp solution until the fix of the synchronize method 