### PR TITLE
copy the doc first to use in elasticSearch to avoid inadvertently pop…

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,4 +1,5 @@
 import { MongoosasticDocument } from './types'
+import { cloneDeep } from 'lodash'
 
 export async function postSave(doc: MongoosasticDocument): Promise<void> {
   if (!doc) {
@@ -20,7 +21,7 @@ export async function postSave(doc: MongoosasticDocument): Promise<void> {
   const populate = options && options.populate
   if (doc) {
     if (populate && populate.length) {
-      const popDoc = await doc.populate(populate)
+      const popDoc = await cloneDeep(doc).populate(populate)
       popDoc
         .index()
         .then((res) => onIndex(null, res))


### PR DESCRIPTION
This change has been made as part of the mongoose upgrade to v6, this ensures that the populate only occurs in elastic search and that it doesn't make any changes to the document in the main record collections