### PR TITLE
Fix #534 issue where subdocuments can be indexed even if no es_indexe…

### DIFF
--- a/test/mapping.test.ts
+++ b/test/mapping.test.ts
@@ -187,6 +187,10 @@ describe('MappingGenerator', function () {
           telephone: {
             type: String
           },
+          social: {
+            messenger : String,
+            instagram: String
+          },
           keys: [String],
           tags: {
             type: [String],
@@ -201,6 +205,7 @@ describe('MappingGenerator', function () {
       expect(mapping.properties.contact.properties.tags.type).toEqual('text')
       expect(mapping.properties.contact.properties).not.toHaveProperty('telephone')
       expect(mapping.properties.contact.properties).not.toHaveProperty('keys')
+      expect(mapping.properties.contact.properties).not.toHaveProperty('social')
       done()
     })
 


### PR DESCRIPTION
Hey there!

We recently discovered an issue related to https://github.com/mongoosastic/mongoosastic/issues/534

Subdocuments can be indexed, even if `es_indexed: true` is not there.

We updated the test case, and using the version on the master, it is embedding the subdocument. Using this patched version, it won't