### PR TITLE
Cache generated mapped results

### DIFF
--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -335,13 +335,34 @@ function nestedSchema(
 }
 
 export default class Generator {
-  generateMapping(schema: Schema<MongoosasticDocument, MongoosasticModel<MongoosasticDocument>>): Record<string, any> {
+  cache: Record<string, Record<string, any>> = {}
+
+  generateMapping(schema: Schema<MongoosasticDocument, MongoosasticModel<MongoosasticDocument>>, useCache?: boolean): Record<string, any> {
+    // Use cached version if any
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    if (useCache && this.cache[schema]) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return this.cache[schema]
+    }
+
     const cleanTree = getCleanTree(schema['tree' as keyof Schema], schema.paths, '', true)
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     delete cleanTree[schema.get('versionKey')]
+
     const mapping = getMapping(cleanTree, '').mapping
-    return { properties: mapping }
+
+    const _cachedMapping = { properties: mapping }
+
+    if (useCache) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.cache[schema] = _cachedMapping
+    }
+
+    return _cachedMapping
   }
 
   getCleanTree(schema: Schema<MongoosasticDocument, MongoosasticModel<MongoosasticDocument>>): Record<string, any> {

--- a/lib/statics.ts
+++ b/lib/statics.ts
@@ -19,7 +19,7 @@ export async function createMapping(
   const generator = new Generator()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const completeMapping = generator.generateMapping(this.schema)
+  const completeMapping = generator.generateMapping(this.schema, true)
 
   completeMapping.properties = filterMappingFromMixed(completeMapping.properties)
 

--- a/test/mapping.test.ts
+++ b/test/mapping.test.ts
@@ -674,6 +674,37 @@ describe('MappingGenerator', function () {
       expect(mapping.properties.locations.properties.coordinates.type).toEqual('geo_point')
       done()
     })
-  })
 
+    describe('generator caching', function () {
+      it('generaterd mappings should not be cached', function (done) {
+        const schema = new Schema({
+          name: {
+            type: String,
+            es_type: 'date'
+          }
+        })
+
+        const mapping_a = generator.generateMapping(schema)
+        const mapping_b = generator.generateMapping(schema)
+
+        expect(mapping_a === mapping_b).toEqual(false)
+        done()
+      })
+
+      it('generaterd mappings should be cached', function (done) {
+        const schema = new Schema({
+          name: {
+            type: String,
+            es_type: 'date'
+          }
+        })
+
+        const mapping_a = generator.generateMapping(schema, true)
+        const mapping_b = generator.generateMapping(schema, true)
+
+        expect(mapping_a === mapping_b).toEqual(true)
+        done()
+      })
+    })
+  })
 })

--- a/test/mapping.test.ts
+++ b/test/mapping.test.ts
@@ -187,6 +187,10 @@ describe('MappingGenerator', function () {
           telephone: {
             type: String
           },
+          social: {
+            messenger : String,
+            instagram: String
+          },
           keys: [String],
           tags: {
             type: [String],
@@ -201,6 +205,7 @@ describe('MappingGenerator', function () {
       expect(mapping.properties.contact.properties.tags.type).toEqual('text')
       expect(mapping.properties.contact.properties).not.toHaveProperty('telephone')
       expect(mapping.properties.contact.properties).not.toHaveProperty('keys')
+      expect(mapping.properties.contact.properties).not.toHaveProperty('social')
       done()
     })
 


### PR DESCRIPTION
Hey there.

I just discovered a potential scaling concern with this package. It appears schema mappings are generated everytime a document is indexed in Elasticsearch (see https://github.com/mongoosastic/mongoosastic/blob/master/lib/methods.ts#L26)

As schema mapping is a CPU-intensive operation (recursions, regexes), mappings should be cached.