### PR TITLE
Fix(bulking): correct property that usage... not pretty though

### DIFF
--- a/lib/bulking.ts
+++ b/lib/bulking.ts
@@ -66,7 +66,13 @@ export async function flush(this: MongoosasticModel<MongoosasticDocument>): Prom
       body: bulkBuffer,
     })
     .then((res) => {
-      if (res.body.items && res.body.items.length) {
+
+      const itemKey = 'items'
+      const objectValues = Object.entries(res)
+      const [, items] = objectValues.find(([key]) => key === itemKey) as [string, Array<any>]
+
+
+      if (items && items.length) {
         for (let i = 0; i < res.body.items.length; i++) {
           const info = res.body.items[i]
           if (info && info.index && info.index.error) {


### PR DESCRIPTION
I tried to fix the error but this is not pretty - and there's a bunch of other errors.. 
anyways, the problem is that when i test this with our setup everything goes down when I try to bulk index our documents on: 

// wrong ❌
`res.body.items`

//correct ✅ 
`res.items`

Seems like they have typed their library wrong, and as mentioned, there are other problems as well... If i hotfix-this in node_modules in colosseum it works, the property is wrong. 